### PR TITLE
AV-1774: Exclude apisets from package_search

### DIFF
--- a/ckanext/apis/plugin.py
+++ b/ckanext/apis/plugin.py
@@ -6,6 +6,7 @@ from .logic.action import get, create, update, delete
 class ApisPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IPackageController, inherit=True)
 
     # IConfigurer
 
@@ -23,3 +24,13 @@ class ApisPlugin(plugins.SingletonPlugin):
                 'apiset_patch': update.apiset_patch,
                 'apiset_delete': delete.apiset_delete
                 }
+
+    def before_search(self, search_params):
+        '''Prevents the apisets being shown in dataset search results.'''
+
+        fq = search_params.get('fq', '')
+        if 'dataset_type:apiset' not in fq:
+            fq = u"{0} -dataset_type:apiset".format(search_params.get('fq', ''))
+            search_params.update({'fq': fq})
+
+        return search_params

--- a/ckanext/apis/plugin.py
+++ b/ckanext/apis/plugin.py
@@ -30,7 +30,7 @@ class ApisPlugin(plugins.SingletonPlugin):
 
         fq = search_params.get('fq', '')
         if 'dataset_type:apiset' not in fq:
-            fq = u"{0} -dataset_type:apiset".format(search_params.get('fq', ''))
-            search_params.update({'fq': fq})
+            fq = u"{0} -dataset_type:apiset".format(fq)
+            search_params['fq'] = fq
 
         return search_params


### PR DESCRIPTION
Group read uses package_search to show group's datasets, this included apisets as they had not been filtered out like harvesters and showcases were.