### PR TITLE
feat(AV-1694): apiset managed datasets

### DIFF
--- a/ckanext/apis/helpers.py
+++ b/ckanext/apis/helpers.py
@@ -1,0 +1,17 @@
+import ckan.model as model
+from ckan.plugins import toolkit as tk
+
+c = tk.c
+get_action = tk.get_action
+
+def get_apiset_pkgs(apiset_id):
+
+    context = {'model': model, 'session': model.Session,
+               'user': c.user or c.author, 'auth_user_obj': c.userobj}
+
+    apiset_pkgs = get_action('apiset_package_list')(context, {'apiset_id': apiset_id})
+
+    return apiset_pkgs
+
+def get_wysiwyg_editor():
+    return tk.config.get('ckanext.apis.editor', '')

--- a/ckanext/apis/helpers.py
+++ b/ckanext/apis/helpers.py
@@ -1,13 +1,13 @@
 import ckan.model as model
 from ckan.plugins import toolkit as tk
 
-c = tk.c
+g = tk.g
 get_action = tk.get_action
 
 def get_apiset_pkgs(apiset_id):
 
     context = {'model': model, 'session': model.Session,
-               'user': c.user or c.author, 'auth_user_obj': c.userobj}
+               'user': g.user or g.author, 'auth_user_obj': g.userobj}
 
     apiset_pkgs = get_action('apiset_package_list')(context, {'apiset_id': apiset_id})
 

--- a/ckanext/apis/logic/action/create.py
+++ b/ckanext/apis/logic/action/create.py
@@ -1,6 +1,29 @@
 import ckan.plugins.toolkit as toolkit
-
+from ckan.lib.navl.dictization_functions import validate
+from ckanext.apis.logic.schema import apiset_package_association_create_schema
+from ckanext.apis.model import ApisetPackageAssociation
+from ckanext.apis.logic.converters import (convert_package_name_or_id_to_title_or_name)
+import logging
 
 def apiset_create(context, data_dict):
     data_dict['type'] = 'apiset'
     return toolkit.get_action('package_create')(context, data_dict)
+
+def apiset_package_association_create(context, data_dict):
+
+    toolkit.check_access('apiset_package_association_create', context, data_dict)
+    validated_data_dict, errors = validate(data_dict, apiset_package_association_create_schema(), context)
+
+    if errors:
+        raise toolkit.ValidationError(errors)
+
+    package_id, apiset_id = toolkit.get_or_bust(validated_data_dict, ['package_id', 'apiset_id'])
+
+    if ApisetPackageAssociation.exists(package_id=package_id, apiset_id=apiset_id):
+        raise toolkit.ValidationError(
+            "ApisetPackageAssociation with package_id '{0}' and apiset_id '{1}' already exists.".format(package_id,
+                                                                                                        apiset_id),
+            error_summary=u"The dataset, {0}, is already in the apiset".format(
+                convert_package_name_or_id_to_title_or_name(package_id, context)))
+
+    return ApisetPackageAssociation.create(package_id=package_id, apiset_id=apiset_id)

--- a/ckanext/apis/logic/action/create.py
+++ b/ckanext/apis/logic/action/create.py
@@ -14,10 +14,17 @@ def apiset_package_association_create(context, data_dict):
     toolkit.check_access('apiset_package_association_create', context, data_dict)
     validated_data_dict, errors = validate(data_dict, apiset_package_association_create_schema(), context)
 
+    logging.warning("Got to before errors")
+
     if errors:
+        logging.error("Got to validation error occurred")
+        logging.error(errors)
         raise toolkit.ValidationError(errors)
 
     package_id, apiset_id = toolkit.get_or_bust(validated_data_dict, ['package_id', 'apiset_id'])
+
+    logging.warning("Got to asscoation exists")
+
 
     if ApisetPackageAssociation.exists(package_id=package_id, apiset_id=apiset_id):
         raise toolkit.ValidationError(
@@ -25,5 +32,7 @@ def apiset_package_association_create(context, data_dict):
                                                                                                         apiset_id),
             error_summary=u"The dataset, {0}, is already in the apiset".format(
                 convert_package_name_or_id_to_title_or_name(package_id, context)))
+
+    logging.warning("Got to return")
 
     return ApisetPackageAssociation.create(package_id=package_id, apiset_id=apiset_id)

--- a/ckanext/apis/logic/action/create.py
+++ b/ckanext/apis/logic/action/create.py
@@ -14,17 +14,10 @@ def apiset_package_association_create(context, data_dict):
     toolkit.check_access('apiset_package_association_create', context, data_dict)
     validated_data_dict, errors = validate(data_dict, apiset_package_association_create_schema(), context)
 
-    logging.warning("Got to before errors")
-
     if errors:
-        logging.error("Got to validation error occurred")
-        logging.error(errors)
         raise toolkit.ValidationError(errors)
 
     package_id, apiset_id = toolkit.get_or_bust(validated_data_dict, ['package_id', 'apiset_id'])
-
-    logging.warning("Got to asscoation exists")
-
 
     if ApisetPackageAssociation.exists(package_id=package_id, apiset_id=apiset_id):
         raise toolkit.ValidationError(
@@ -32,7 +25,5 @@ def apiset_package_association_create(context, data_dict):
                                                                                                         apiset_id),
             error_summary=u"The dataset, {0}, is already in the apiset".format(
                 convert_package_name_or_id_to_title_or_name(package_id, context)))
-
-    logging.warning("Got to return")
 
     return ApisetPackageAssociation.create(package_id=package_id, apiset_id=apiset_id)

--- a/ckanext/apis/logic/action/delete.py
+++ b/ckanext/apis/logic/action/delete.py
@@ -1,8 +1,7 @@
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.navl.dictization_functions import validate
-from ckanext.apis.logic.schema import apiset_package_association_delete_schema, apiset_admin_remove_schema
-from ckanext.apis.model import ApisetPackageAssociation#, ApisetAdmin
-from ckan.logic.converters import convert_user_name_or_id_to_id
+from ckanext.apis.logic.schema import apiset_package_association_delete_schema
+from ckanext.apis.model import ApisetPackageAssociation
 
 
 def apiset_delete(context, data_dict):
@@ -25,23 +24,3 @@ def apiset_package_association_delete(context, data_dict):
 
     apiset_package_association.delete()
     model.repo.commit()
-
-
-# def apiset_admin_remove(context, data_dict):
-#     model = context['model']
-#     toolkit.check_access('apiset_admin_remove', context, data_dict)
-#     validated_data_dict, errors = validate(data_dict, apiset_admin_remove_schema(), context)
-
-#     if errors:
-#         raise toolkit.ValidationError(errors)
-
-#     username = toolkit.get_or_bust(validated_data_dict, 'username')
-#     user_id = convert_user_name_or_id_to_id(username, context)
-
-#     sapiset_admin_to_remove = ApisetAdmin.get(user_id=user_id)
-
-#     if sapiset_admin_to_remove is None:
-#         raise toolkit.ObjectNotFound("ApisetAdmin with user_id '{0}' doesn't exist.".format(user_id))
-
-#     sapiset_admin_to_remove.delete()
-#     model.repo.commit()

--- a/ckanext/apis/logic/action/delete.py
+++ b/ckanext/apis/logic/action/delete.py
@@ -1,7 +1,7 @@
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.navl.dictization_functions import validate
 from ckanext.apis.logic.schema import apiset_package_association_delete_schema, apiset_admin_remove_schema
-from ckanext.apis.model import ApisetPackageAssociation, ApisetAdmin
+from ckanext.apis.model import ApisetPackageAssociation#, ApisetAdmin
 from ckan.logic.converters import convert_user_name_or_id_to_id
 
 
@@ -27,21 +27,21 @@ def apiset_package_association_delete(context, data_dict):
     model.repo.commit()
 
 
-def apiset_admin_remove(context, data_dict):
-    model = context['model']
-    toolkit.check_access('apiset_admin_remove', context, data_dict)
-    validated_data_dict, errors = validate(data_dict, apiset_admin_remove_schema(), context)
+# def apiset_admin_remove(context, data_dict):
+#     model = context['model']
+#     toolkit.check_access('apiset_admin_remove', context, data_dict)
+#     validated_data_dict, errors = validate(data_dict, apiset_admin_remove_schema(), context)
 
-    if errors:
-        raise toolkit.ValidationError(errors)
+#     if errors:
+#         raise toolkit.ValidationError(errors)
 
-    username = toolkit.get_or_bust(validated_data_dict, 'username')
-    user_id = convert_user_name_or_id_to_id(username, context)
+#     username = toolkit.get_or_bust(validated_data_dict, 'username')
+#     user_id = convert_user_name_or_id_to_id(username, context)
 
-    sapiset_admin_to_remove = ApisetAdmin.get(user_id=user_id)
+#     sapiset_admin_to_remove = ApisetAdmin.get(user_id=user_id)
 
-    if sapiset_admin_to_remove is None:
-        raise toolkit.ObjectNotFound("ApisetAdmin with user_id '{0}' doesn't exist.".format(user_id))
+#     if sapiset_admin_to_remove is None:
+#         raise toolkit.ObjectNotFound("ApisetAdmin with user_id '{0}' doesn't exist.".format(user_id))
 
-    sapiset_admin_to_remove.delete()
-    model.repo.commit()
+#     sapiset_admin_to_remove.delete()
+#     model.repo.commit()

--- a/ckanext/apis/logic/action/delete.py
+++ b/ckanext/apis/logic/action/delete.py
@@ -1,5 +1,47 @@
 import ckan.plugins.toolkit as toolkit
+from ckan.lib.navl.dictization_functions import validate
+from ckanext.apis.logic.schema import apiset_package_association_delete_schema, apiset_admin_remove_schema
+from ckanext.apis.model import ApisetPackageAssociation, ApisetAdmin
+from ckan.logic.converters import convert_user_name_or_id_to_id
 
 
 def apiset_delete(context, data_dict):
     return toolkit.get_action('package_delete')(context, data_dict)
+
+def apiset_package_association_delete(context, data_dict):
+    model = context['model']
+    toolkit.check_access('apiset_package_association_delete', context, data_dict)
+    validated_data_dict, errors = validate(data_dict, apiset_package_association_delete_schema(), context)
+
+    if errors:
+        raise toolkit.ValidationError(errors)
+
+    package_id, apiset_id = toolkit.get_or_bust(validated_data_dict, ['package_id', 'apiset_id'])
+    apiset_package_association = ApisetPackageAssociation.get(package_id=package_id, apiset_id=apiset_id)
+
+    if apiset_package_association is None:
+        raise toolkit.ObjectNotFound(
+            "ApisetPackageAssociation with package_id '{0}' and apiset_id '{1}' doesn't exist.".format(package_id, apiset_id))
+
+    apiset_package_association.delete()
+    model.repo.commit()
+
+
+def apiset_admin_remove(context, data_dict):
+    model = context['model']
+    toolkit.check_access('apiset_admin_remove', context, data_dict)
+    validated_data_dict, errors = validate(data_dict, apiset_admin_remove_schema(), context)
+
+    if errors:
+        raise toolkit.ValidationError(errors)
+
+    username = toolkit.get_or_bust(validated_data_dict, 'username')
+    user_id = convert_user_name_or_id_to_id(username, context)
+
+    sapiset_admin_to_remove = ApisetAdmin.get(user_id=user_id)
+
+    if sapiset_admin_to_remove is None:
+        raise toolkit.ObjectNotFound("ApisetAdmin with user_id '{0}' doesn't exist.".format(user_id))
+
+    sapiset_admin_to_remove.delete()
+    model.repo.commit()

--- a/ckanext/apis/logic/action/get.py
+++ b/ckanext/apis/logic/action/get.py
@@ -3,7 +3,7 @@ import ckan.lib.dictization.model_dictize as model_dictize
 
 from ckan.lib.navl.dictization_functions import validate
 from ckanext.apis.logic.schema import apiset_package_list_schema, package_apiset_list_schema
-from ckanext.apis.model import ApisetPackageAssociation, ApisetAdmin
+from ckanext.apis.model import ApisetPackageAssociation#, ApisetAdmin
 
 @toolkit.side_effect_free
 def apiset_show(context, data_dict):
@@ -73,21 +73,21 @@ def package_apiset_list(context, data_dict):
     return package_list
 
 
-@toolkit.side_effect_free
-def apiset_admin_list(context, data_dict):
-    toolkit.check_access('apiset_admin_list', context, data_dict)
-    model = context["model"]
-    user_ids = ApisetAdmin.get_apiset_admin_ids()
+# @toolkit.side_effect_free
+# def apiset_admin_list(context, data_dict):
+#     toolkit.check_access('apiset_admin_list', context, data_dict)
+#     model = context["model"]
+#     user_ids = ApisetAdmin.get_apiset_admin_ids()
 
-    if user_ids:
-        q = model.Session.query(model.User) \
-            .filter(model.User.state == 'active') \
-            .filter(model.User.id.in_(user_ids))
+#     if user_ids:
+#         q = model.Session.query(model.User) \
+#             .filter(model.User.state == 'active') \
+#             .filter(model.User.id.in_(user_ids))
 
-        showcase_admin_list = []
-        for user in q.all():
-            showcase_admin_list.append({'name': user.name, 'id': user.id})
-        return showcase_admin_list
+#         showcase_admin_list = []
+#         for user in q.all():
+#             showcase_admin_list.append({'name': user.name, 'id': user.id})
+#         return showcase_admin_list
 
-    return []
+#     return []
 

--- a/ckanext/apis/logic/action/get.py
+++ b/ckanext/apis/logic/action/get.py
@@ -3,7 +3,7 @@ import ckan.lib.dictization.model_dictize as model_dictize
 
 from ckan.lib.navl.dictization_functions import validate
 from ckanext.apis.logic.schema import apiset_package_list_schema, package_apiset_list_schema
-from ckanext.apis.model import ApisetPackageAssociation#, ApisetAdmin
+from ckanext.apis.model import ApisetPackageAssociation
 
 @toolkit.side_effect_free
 def apiset_show(context, data_dict):
@@ -71,23 +71,3 @@ def package_apiset_list(context, data_dict):
         package_list = _package_list['results']
 
     return package_list
-
-
-# @toolkit.side_effect_free
-# def apiset_admin_list(context, data_dict):
-#     toolkit.check_access('apiset_admin_list', context, data_dict)
-#     model = context["model"]
-#     user_ids = ApisetAdmin.get_apiset_admin_ids()
-
-#     if user_ids:
-#         q = model.Session.query(model.User) \
-#             .filter(model.User.state == 'active') \
-#             .filter(model.User.id.in_(user_ids))
-
-#         showcase_admin_list = []
-#         for user in q.all():
-#             showcase_admin_list.append({'name': user.name, 'id': user.id})
-#         return showcase_admin_list
-
-#     return []
-

--- a/ckanext/apis/logic/action/get.py
+++ b/ckanext/apis/logic/action/get.py
@@ -8,6 +8,7 @@ from ckanext.apis.model import ApisetPackageAssociation, ApisetAdmin
 @toolkit.side_effect_free
 def apiset_show(context, data_dict):
     return toolkit.get_action('package_show')(context, data_dict)
+
 @toolkit.side_effect_free
 def apiset_list(context, data_dict):
     model = context["model"]
@@ -23,7 +24,6 @@ def apiset_list(context, data_dict):
         q = q.offset(offset)
 
     return [model_dictize.package_dictize(pkg, context) for pkg in q.all()]
-
 
 @toolkit.side_effect_free
 def apiset_package_list(context, data_dict):

--- a/ckanext/apis/logic/action/get.py
+++ b/ckanext/apis/logic/action/get.py
@@ -1,27 +1,93 @@
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.dictization.model_dictize as model_dictize
 
+from ckan.lib.navl.dictization_functions import validate
+from ckanext.apis.logic.schema import apiset_package_list_schema, package_apiset_list_schema
+from ckanext.apis.model import ApisetPackageAssociation, ApisetAdmin
 
 @toolkit.side_effect_free
 def apiset_show(context, data_dict):
     return toolkit.get_action('package_show')(context, data_dict)
-
-
 @toolkit.side_effect_free
 def apiset_list(context, data_dict):
     model = context["model"]
-
     q = (model.Session.query(model.Package)
          .filter(model.Package.type == 'apiset')
          .filter(model.Package.private == False) # noqa
          .filter(model.Package.state == 'active'))
-
     limit = data_dict.get('limit')
     if limit:
         q = q.limit(limit)
-
     offset = data_dict.get('offset')
     if offset:
         q = q.offset(offset)
 
     return [model_dictize.package_dictize(pkg, context) for pkg in q.all()]
+
+
+@toolkit.side_effect_free
+def apiset_package_list(context, data_dict):
+    toolkit.check_access('apiset_package_list', context.copy(), data_dict)
+    validated_data_dict, errors = validate(data_dict, apiset_package_list_schema(), context.copy())
+
+    if errors:
+        raise toolkit.ValidationError(errors)
+
+    pkg_id_list = ApisetPackageAssociation.get_package_ids_for_apiset(validated_data_dict['apiset_id'])
+
+    pkg_list = []
+    if pkg_id_list:
+        id_list = []
+        for pkg_id in pkg_id_list:
+            id_list.append(pkg_id[0])
+        q = ' OR '.join(['id:{0}'.format(x) for x in id_list])
+        _pkg_list = toolkit.get_action('package_search')(
+            context,
+            {'q': q, 'rows': 100})
+        pkg_list = _pkg_list['results']
+    return pkg_list
+
+
+@toolkit.side_effect_free
+def package_apiset_list(context, data_dict):
+    toolkit.check_access('package_apiset_list', context, data_dict)
+    validated_data_dict, errors = validate(data_dict, package_apiset_list_schema(), context)
+
+    if errors:
+        raise toolkit.ValidationError(errors)
+
+    apiset_id_list = ApisetPackageAssociation.get_apiset_ids_for_package(validated_data_dict['package_id'])
+    package_list = []
+
+    if apiset_id_list:
+        id_list = []
+        for apiset_id in apiset_id_list:
+            id_list.append(apiset_id[0])
+        fq = 'dataset_type:showcase'
+        q = ' OR '.join(['id:{0}'.format(x) for x in id_list])
+        _package_list = toolkit.get_action('package_search')(
+            context,
+            {'q': q, 'fq': fq, 'rows': 100})
+        package_list = _package_list['results']
+
+    return package_list
+
+
+@toolkit.side_effect_free
+def apiset_admin_list(context, data_dict):
+    toolkit.check_access('apiset_admin_list', context, data_dict)
+    model = context["model"]
+    user_ids = ApisetAdmin.get_apiset_admin_ids()
+
+    if user_ids:
+        q = model.Session.query(model.User) \
+            .filter(model.User.state == 'active') \
+            .filter(model.User.id.in_(user_ids))
+
+        showcase_admin_list = []
+        for user in q.all():
+            showcase_admin_list.append({'name': user.name, 'id': user.id})
+        return showcase_admin_list
+
+    return []
+

--- a/ckanext/apis/logic/auth.py
+++ b/ckanext/apis/logic/auth.py
@@ -18,6 +18,7 @@ def get_auth_functions():
         'apiset_package_association_create': apiset_association_create,
         'apiset_delete': apiset_delete,
         'apiset_package_association_delete': apiset_association_delete,
+        'apiset_update': apiset_update,
         'apiset_admin_remove': remove_apiset_admin,
         'apiset_package_list': apiset_package_list,
         'package_apiset_list': package_apiset_list,
@@ -39,6 +40,15 @@ def apiset_admin_list(context, data_dict):
 
 def remove_apiset_admin(context, data_dict):
     return {'success': False}
+
+def apiset_update(context, data_dict):
+    user = context.get('user')
+    try:
+        toolkit.check_access('package_update', context, data_dict)
+        return {'success': True}
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': toolkit._('User {0} not authorized to edit apisets').format(user)}
 
 def apiset_create(context, data_dict):
     user = context.get('user')

--- a/ckanext/apis/logic/auth.py
+++ b/ckanext/apis/logic/auth.py
@@ -1,0 +1,57 @@
+import logging
+import ckan.model as model
+from ckan.plugins import toolkit
+from ckanext.apis.model import ApisetAdmin
+
+log = logging.getLogger(__name__)
+
+
+def _is_apiset_admin(context):
+    user = context.get('user', '')
+    userobj = model.User.get(user)
+    return ApisetAdmin.is_user_apiset_admin(userobj)
+
+
+def get_auth_functions():
+    return {
+        'apiset_create': apiset_create,
+        'apiset_package_association_create': apiset_association_create,
+        'apiset_delete': apiset_delete,
+        'apiset_package_association_delete': apiset_association_delete,
+        'apiset_admin_remove': remove_apiset_admin,
+        'apiset_package_list': apiset_package_list,
+        'package_apiset_list': package_apiset_list,
+        'apiset_admin_list': apiset_admin_list,
+    }
+
+
+
+@toolkit.auth_allow_anonymous_access
+def apiset_package_list(context, data_dict):
+    return {'success': True}
+
+
+@toolkit.auth_allow_anonymous_access
+def package_apiset_list(context, data_dict):
+    return {'success': True}
+
+
+def apiset_admin_list(context, data_dict):
+    return {'success': False}
+
+
+def remove_apiset_admin(context, data_dict):
+    return {'success': False}
+
+
+def apiset_create(context, data_dict):
+    return {'success': _is_apiset_admin(context)}
+
+def apiset_association_create(context, data_dict):
+    return {'success': _is_apiset_admin(context)}
+
+def apiset_delete(context, data_dict):
+    return {'success': _is_apiset_admin(context)}
+
+def apiset_association_delete(context, data_dict):
+    return {'success': _is_apiset_admin(context)}

--- a/ckanext/apis/logic/auth.py
+++ b/ckanext/apis/logic/auth.py
@@ -1,7 +1,7 @@
 import logging
 import ckan.model as model
 from ckan.plugins import toolkit
-from ckanext.apis.model import ApisetAdmin
+# from ckanext.apis.model import ApisetAdmin
 
 log = logging.getLogger(__name__)
 
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 def _is_apiset_admin(context):
     user = context.get('user', '')
     userobj = model.User.get(user)
-    return ApisetAdmin.is_user_apiset_admin(userobj)
+    # return ApisetAdmin.is_user_apiset_admin(userobj)
 
 
 def get_auth_functions():
@@ -30,28 +30,49 @@ def get_auth_functions():
 def apiset_package_list(context, data_dict):
     return {'success': True}
 
-
 @toolkit.auth_allow_anonymous_access
 def package_apiset_list(context, data_dict):
     return {'success': True}
 
-
 def apiset_admin_list(context, data_dict):
     return {'success': False}
-
 
 def remove_apiset_admin(context, data_dict):
     return {'success': False}
 
-
 def apiset_create(context, data_dict):
-    return {'success': _is_apiset_admin(context)}
+    user = context.get('user')
+    try:
+        toolkit.check_access('package_create', context, data_dict)
+        return {'success': True}
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': toolkit._('User {0} not authorized to create apisets').format(user)}
 
 def apiset_association_create(context, data_dict):
-    return {'success': _is_apiset_admin(context)}
+    user = context.get('user')
+    try:
+        toolkit.check_access('package_create', context, data_dict)
+        return {'success': True}
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': toolkit._('User {0} not authorized to associate apisets').format(user)}
+
 
 def apiset_delete(context, data_dict):
-    return {'success': _is_apiset_admin(context)}
+    user = context.get('user')
+    try:
+        toolkit.check_access('package_delete', context, data_dict)
+        return {'success': True}
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': toolkit._('User {0} not authorized to delete apisets').format(user)}
 
 def apiset_association_delete(context, data_dict):
-    return {'success': _is_apiset_admin(context)}
+    user = context.get('user')
+    try:
+        toolkit.check_access('package_delete', context, data_dict)
+        return {'success': True}
+    except toolkit.NotAuthorized:
+        return {'success': False,
+                'msg': toolkit._('User {0} not authorized to delete apiset associations').format(user)}

--- a/ckanext/apis/logic/auth.py
+++ b/ckanext/apis/logic/auth.py
@@ -54,7 +54,7 @@ def apiset_create(context, data_dict):
 def apiset_association_create(context, data_dict):
     user = context.get('user')
     try:
-        toolkit.check_access('package_create', context, data_dict)
+        toolkit.check_access('package_update', context, data_dict)
         return {'success': True}
     except toolkit.NotAuthorized:
         return {'success': False,

--- a/ckanext/apis/logic/auth.py
+++ b/ckanext/apis/logic/auth.py
@@ -1,15 +1,8 @@
 import logging
 import ckan.model as model
 from ckan.plugins import toolkit
-# from ckanext.apis.model import ApisetAdmin
 
 log = logging.getLogger(__name__)
-
-
-def _is_apiset_admin(context):
-    user = context.get('user', '')
-    userobj = model.User.get(user)
-    # return ApisetAdmin.is_user_apiset_admin(userobj)
 
 
 def get_auth_functions():
@@ -24,7 +17,6 @@ def get_auth_functions():
         'package_apiset_list': package_apiset_list,
         'apiset_admin_list': apiset_admin_list,
     }
-
 
 
 @toolkit.auth_allow_anonymous_access

--- a/ckanext/apis/logic/converters.py
+++ b/ckanext/apis/logic/converters.py
@@ -1,0 +1,15 @@
+import ckan.model as model
+import ckan.lib.navl.dictization_functions as df
+from ckan.common import _
+
+
+def convert_package_name_or_id_to_title_or_name(package_name_or_id, context):
+    session = context['session']
+    result = session.query(model.Package).filter_by(
+            id=package_name_or_id).first()
+    if not result:
+        result = session.query(model.Package).filter_by(
+                name=package_name_or_id).first()
+    if not result:
+        raise df.Invalid('%s: %s' % (_('Not found'), _('Dataset')))
+    return result.title or result.name

--- a/ckanext/apis/logic/converters.py
+++ b/ckanext/apis/logic/converters.py
@@ -1,6 +1,9 @@
 import ckan.model as model
 import ckan.lib.navl.dictization_functions as df
 from ckan.common import _
+from ckan.lib.navl.dictization_functions import  missing, flatten_list, StopOnError
+import json
+import logging
 
 
 def convert_package_name_or_id_to_title_or_name(package_name_or_id, context):
@@ -13,3 +16,37 @@ def convert_package_name_or_id_to_title_or_name(package_name_or_id, context):
     if not result:
         raise df.Invalid('%s: %s' % (_('Not found'), _('Dataset')))
     return result.title or result.name
+
+
+def save_to_groups(key, data, errors, context):
+    # https://docs.ckan.org/en/ckan-2.7.3/api/#ckan.logic.action.create.package_create
+    # Add selected items as groups to dataset
+    value = data[key]
+
+    if value and value is not missing:
+
+        if isinstance(value, str):
+            group_patch = flatten_list([{"name": value}])
+            group_key = ('groups',) + list(group_patch.keys())[0]
+            group_value = list(group_patch.values())[0]
+            data[group_key] = group_value
+        else:
+            if isinstance(value, list):
+                data[key] = json.dumps(value)
+                groups_with_details = []
+                for identifier in value:
+                    groups_with_details.append({"name": identifier})
+                group_patch = flatten_list(groups_with_details)
+
+                for k, v in list(group_patch.items()):
+                    group_key = ('groups',) + k
+                    data[group_key] = v
+
+    else:
+
+        # Delete categories key if it is missing
+        # TODO: Should delete existing groups from dataset
+        data.pop(key, None)
+        raise StopOnError
+
+    return data[key]

--- a/ckanext/apis/logic/schema.py
+++ b/ckanext/apis/logic/schema.py
@@ -1,0 +1,33 @@
+import six
+from ckan.lib.navl.validators import (not_empty)
+from ckan.logic.validators import user_id_or_name_exists
+from .validators import (convert_package_name_or_id_to_id_for_type_apiset)
+from .validators import (convert_package_name_or_id_to_id_for_type_dataset)
+
+
+def apiset_package_association_create_schema():
+    schema = {
+        'package_id': [not_empty, six.text_type, convert_package_name_or_id_to_id_for_type_dataset],
+        'apiset_id': [not_empty, six.text_type, convert_package_name_or_id_to_id_for_type_apiset]
+    }
+    return schema
+
+
+def apiset_package_association_delete_schema():
+    return apiset_package_association_create_schema()
+
+
+def apiset_package_list_schema():
+    return {'apiset_id': [not_empty, six.text_type, convert_package_name_or_id_to_id_for_type_apiset]}
+
+
+def package_apiset_list_schema():
+    return {'package_id': [not_empty, six.text_type, convert_package_name_or_id_to_id_for_type_dataset]}
+
+
+def apiset_admin_add_schema():
+    return {'username': [not_empty, user_id_or_name_exists, six.text_type]}
+
+
+def apiset_admin_remove_schema():
+    return apiset_admin_add_schema()

--- a/ckanext/apis/logic/validators.py
+++ b/ckanext/apis/logic/validators.py
@@ -1,0 +1,25 @@
+from ckan.plugins import toolkit as tk
+
+_ = tk._
+Invalid = tk.Invalid
+
+
+def convert_package_name_or_id_to_id_for_type_apiset(package_name_or_id, context):
+    return convert_package_name_or_id_to_id_for_type(package_name_or_id, context, package_type='apiset')
+
+
+def convert_package_name_or_id_to_id_for_type_dataset(package_name_or_id, context):
+    return convert_package_name_or_id_to_id_for_type(package_name_or_id, context, package_type='dataset')
+
+
+def convert_package_name_or_id_to_id_for_type(package_name_or_id, context, package_type='dataset'):
+    session = context['session']
+    model = context['model']
+    result = session.query(model.Package) \
+        .filter_by(id=package_name_or_id, type=package_type).first()
+    if not result:
+        result = session.query(model.Package) \
+            .filter_by(name=package_name_or_id, type=package_type).first()
+    if not result:
+        raise Invalid('%s: %s' % (_('Not found'), _('Dataset')))
+    return result.id

--- a/ckanext/apis/model/__init__.py
+++ b/ckanext/apis/model/__init__.py
@@ -9,7 +9,6 @@ import logging
 
 log = logging.getLogger(__name__)
 apiset_package_association_table = None
-apiset_admin_table = None
 
 
 def setup():
@@ -25,19 +24,6 @@ def setup():
             log.debug('ApisetPackageAssociation table already exists')
     else:
         log.debug('ApisetPackageAssociation table creation deferred')
-
-    if apiset_admin_table is None:
-        #define_apiset_admin_table()
-        log.debug('ApisetAdmin table defined in memory')
-
-    # if model.user_table.exists():
-    #     if not apiset_admin_table.exists():
-    #         apiset_admin_table.create()
-    #         log.debug('ApisetAdmin table create')
-    #     else:
-    #         log.debug('ApisetAdmin table already exists')
-    # else:
-    #     log.debug('ApisetAdmin table creation deferred')
 
 
 class ApisetBaseModel(DomainObject):
@@ -95,35 +81,3 @@ def define_apiset_package_association_table():
     )
 
     mapper(ApisetPackageAssociation, apiset_package_association_table)
-
-
-# Delete
-# class ApisetAdmin(ApisetBaseModel):
-#     pass
-
-#     @classmethod
-#     def get_apiset_admin_ids(cls):
-#         id_list = [i for (i, ) in Session.query(cls.user_id).all()]
-#         return id_list
-
-#     @classmethod
-#     def is_user_apiset_admin(cls, user):
-
-#         logging.error(user)
-#         test = cls.get_apiset_admin_ids()
-#         logging.error(test)
-
-#         return (user.id in cls.get_apiset_admin_ids())
-
-
-# def define_apiset_admin_table():
-#     global apiset_admin_table
-
-#     apiset_admin_table = Table('apiset_admin', metadata,
-#                                  Column('user_id', types.UnicodeText,
-#                                         ForeignKey('user.id',
-#                                                    ondelete='CASCADE',
-#                                                    onupdate='CASCADE'),
-#                                         primary_key=True, nullable=False))
-
-    # mapper(ApisetAdmin, apiset_admin_table)

--- a/ckanext/apis/model/__init__.py
+++ b/ckanext/apis/model/__init__.py
@@ -27,17 +27,17 @@ def setup():
         log.debug('ApisetPackageAssociation table creation deferred')
 
     if apiset_admin_table is None:
-        define_apiset_admin_table()
+        #define_apiset_admin_table()
         log.debug('ApisetAdmin table defined in memory')
 
-    if model.user_table.exists():
-        if not apiset_admin_table.exists():
-            apiset_admin_table.create()
-            log.debug('ApisetAdmin table create')
-        else:
-            log.debug('ApisetAdmin table already exists')
-    else:
-        log.debug('ApisetAdmin table creation deferred')
+    # if model.user_table.exists():
+    #     if not apiset_admin_table.exists():
+    #         apiset_admin_table.create()
+    #         log.debug('ApisetAdmin table create')
+    #     else:
+    #         log.debug('ApisetAdmin table already exists')
+    # else:
+    #     log.debug('ApisetAdmin table creation deferred')
 
 
 class ApisetBaseModel(DomainObject):
@@ -97,26 +97,33 @@ def define_apiset_package_association_table():
     mapper(ApisetPackageAssociation, apiset_package_association_table)
 
 
-class ApisetAdmin(ApisetBaseModel):
+# Delete
+# class ApisetAdmin(ApisetBaseModel):
+#     pass
 
-    @classmethod
-    def get_apiset_admin_ids(cls):
-        id_list = [i for (i, ) in Session.query(cls.user_id).all()]
-        return id_list
+#     @classmethod
+#     def get_apiset_admin_ids(cls):
+#         id_list = [i for (i, ) in Session.query(cls.user_id).all()]
+#         return id_list
 
-    @classmethod
-    def is_user_apiset_admin(cls, user):
-        return (user.id in cls.get_apiset_admin_ids())
+#     @classmethod
+#     def is_user_apiset_admin(cls, user):
+
+#         logging.error(user)
+#         test = cls.get_apiset_admin_ids()
+#         logging.error(test)
+
+#         return (user.id in cls.get_apiset_admin_ids())
 
 
-def define_apiset_admin_table():
-    global apiset_admin_table
+# def define_apiset_admin_table():
+#     global apiset_admin_table
 
-    apiset_admin_table = Table('apiset_admin', metadata,
-                                 Column('user_id', types.UnicodeText,
-                                        ForeignKey('user.id',
-                                                   ondelete='CASCADE',
-                                                   onupdate='CASCADE'),
-                                        primary_key=True, nullable=False))
+#     apiset_admin_table = Table('apiset_admin', metadata,
+#                                  Column('user_id', types.UnicodeText,
+#                                         ForeignKey('user.id',
+#                                                    ondelete='CASCADE',
+#                                                    onupdate='CASCADE'),
+#                                         primary_key=True, nullable=False))
 
-    mapper(ApisetAdmin, apiset_admin_table)
+    # mapper(ApisetAdmin, apiset_admin_table)

--- a/ckanext/apis/model/__init__.py
+++ b/ckanext/apis/model/__init__.py
@@ -1,0 +1,122 @@
+from ckan.model.domain_object import DomainObject
+from sqlalchemy import Table
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import types
+from ckan.model.meta import metadata, mapper, Session
+from ckan import model
+import logging
+
+log = logging.getLogger(__name__)
+apiset_package_association_table = None
+apiset_admin_table = None
+
+
+def setup():
+    if apiset_package_association_table is None:
+        define_apiset_package_association_table()
+        log.debug('ApisetPackageAssociation table defined in memory')
+
+    if model.package_table.exists():
+        if not apiset_package_association_table.exists():
+            apiset_package_association_table.create()
+            log.debug('ApisetPackageAssociation table create')
+        else:
+            log.debug('ApisetPackageAssociation table already exists')
+    else:
+        log.debug('ApisetPackageAssociation table creation deferred')
+
+    if apiset_admin_table is None:
+        define_apiset_admin_table()
+        log.debug('ApisetAdmin table defined in memory')
+
+    if model.user_table.exists():
+        if not apiset_admin_table.exists():
+            apiset_admin_table.create()
+            log.debug('ApisetAdmin table create')
+        else:
+            log.debug('ApisetAdmin table already exists')
+    else:
+        log.debug('ApisetAdmin table creation deferred')
+
+
+class ApisetBaseModel(DomainObject):
+    @classmethod
+    def filter(cls, **kwargs):
+        return Session.query(cls).filter_by(**kwargs)
+
+    @classmethod
+    def exists(cls, **kwargs):
+        if cls.filter(**kwargs).first():
+            return True
+        else:
+            return False
+
+    @classmethod
+    def get(cls, **kwargs):
+        instance = cls.filter(**kwargs).first()
+        return instance
+
+    @classmethod
+    def create(cls, **kwargs):
+        instance = cls(**kwargs)
+        Session.add(instance)
+        Session.commit()
+        return instance.as_dict()
+
+
+class ApisetPackageAssociation(ApisetBaseModel):
+    @classmethod
+    def get_package_ids_for_apiset(cls, apiset_id):
+        apiset_package_association_list = Session.query(cls.package_id).filter_by(apiset_id=apiset_id).all()
+        return apiset_package_association_list
+
+    @classmethod
+    def get_apiset_ids_for_package(cls, package_id):
+        package_apiset_association_list = Session.query(cls.apiset_id).filter_by(package_id=package_id).all()
+        return package_apiset_association_list
+
+
+def define_apiset_package_association_table():
+    global apiset_package_association_table
+
+    apiset_package_association_table = Table(
+        'apiset_package_association', metadata,
+        Column('package_id', types.UnicodeText,
+               ForeignKey('package.id',
+                          ondelete='CASCADE',
+                          onupdate='CASCADE'),
+               primary_key=True, nullable=False),
+        Column('apiset_id', types.UnicodeText,
+               ForeignKey('package.id',
+                          ondelete='CASCADE',
+                          onupdate='CASCADE'),
+               primary_key=True, nullable=False)
+    )
+
+    mapper(ApisetPackageAssociation, apiset_package_association_table)
+
+
+class ApisetAdmin(ApisetBaseModel):
+
+    @classmethod
+    def get_apiset_admin_ids(cls):
+        id_list = [i for (i, ) in Session.query(cls.user_id).all()]
+        return id_list
+
+    @classmethod
+    def is_user_apiset_admin(cls, user):
+        return (user.id in cls.get_apiset_admin_ids())
+
+
+def define_apiset_admin_table():
+    global apiset_admin_table
+
+    apiset_admin_table = Table('apiset_admin', metadata,
+                                 Column('user_id', types.UnicodeText,
+                                        ForeignKey('user.id',
+                                                   ondelete='CASCADE',
+                                                   onupdate='CASCADE'),
+                                        primary_key=True, nullable=False))
+
+    mapper(ApisetAdmin, apiset_admin_table)

--- a/ckanext/apis/plugin.py
+++ b/ckanext/apis/plugin.py
@@ -8,6 +8,8 @@ from . import views
 from ckanext.apis.model import setup as model_setup
 from . import helpers
 from ckanext.apis.logic import auth
+import os
+import sys
 import json
 import logging
 
@@ -34,7 +36,6 @@ class ApisPlugin(plugins.SingletonPlugin):
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'apis')
         
-
     def get_actions(self):
         return {
                 'apiset_show': get.apiset_show,
@@ -77,3 +78,38 @@ class ApisPlugin(plugins.SingletonPlugin):
         return {
             'get_apiset_pkgs': helpers.get_apiset_pkgs
         }
+
+    # ITranslation
+
+    # The following methods copied from ckan.lib.plugins.DefaultTranslation so
+    # we don't have to mix it into the class. This means we can use Apiset
+    # even if ITranslation isn't available (less than 2.5).
+    
+    def i18n_directory(self):
+            '''Change the directory of the *.mo translation files
+            The default implementation assumes the plugin is
+            ckanext/myplugin/plugin.py and the translations are stored in
+            i18n/
+            '''
+            # assume plugin is called ckanext.<myplugin>.<...>.PluginClass
+            extension_module_name = '.'.join(self.__module__.split('.')[0:2])
+            module = sys.modules[extension_module_name]
+            return os.path.join(os.path.dirname(module.__file__), 'i18n')
+
+    def i18n_locales(self):
+        '''Change the list of locales that this plugin handles
+        By default the will assume any directory in subdirectory in the
+        directory defined by self.directory() is a locale handled by this
+        plugin
+        '''
+        directory = self.i18n_directory()
+        return [d for
+                d in os.listdir(directory)
+                if os.path.isdir(os.path.join(directory, d))]
+
+    def i18n_domain(self):
+        '''Change the gettext domain handled by this plugin
+        This implementation assumes the gettext domain is
+        ckanext-{extension name}, hence your pot, po and mo files should be
+        named ckanext-{extension name}.mo'''
+        return 'ckanext-{name}'.format(name=self.name)

--- a/ckanext/apis/plugin.py
+++ b/ckanext/apis/plugin.py
@@ -1,19 +1,72 @@
+# encoding: utf-8
+from __future__ import annotations
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from .logic.action import get, create, update, delete
+from . import views
+from ckanext.apis.model import setup as model_setup
+from . import helpers
+from ckanext.apis.logic import auth
+import json
+import logging
+
+# from ckan.types import Schema
+# import ckan.plugins as p
+# import ckan.plugins.toolkit as tk
 
 
 class ApisPlugin(plugins.SingletonPlugin):
+    # plugins.implements(plugins.IDatasetForm)
+    plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IPackageController, inherit=True)
+    plugins.implements(plugins.IBlueprint)
+    plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IAuthFunctions)
+    # plugins.implements(plugins.IDatasetForm)
+    # plugins.implements(plugins.IFacets, inherit=True)
 
-    # IConfigurer
+
+    # IBlueprint
+    def get_blueprint(self):
+        return views.get_blueprint()
+
+    # # IConfigurer
+    # def update_config(self, config_):
+    #     toolkit.add_template_directory(config_, 'templates')
+    #     toolkit.add_public_directory(config_, 'public')
+    #     toolkit.add_resource('fanstatic', 'apis')
+    #     toolkit.add_ckan_admin_tab(config_, 'apis_blueprint.admins', 'Apiset Config')
+
+    #     if toolkit.check_ckan_version(min_version='2.9.0'):
+    #         mappings = config_.get('ckan.legacy_route_mappings', {})
+    #         if isinstance(mappings, string_types):
+    #             mappings = json.loads(mappings)
+
+    #         bp_routes = [
+    #             'index', 'new', 'delete',
+    #             'read', 'edit', 'manage_datasets',
+    #             'apiset_package_list', 'admins', 'admin_remove'
+    #         ]
+    #         mappings.update({
+    #             'apiset_' + route: 'apis_blueprint.' + route
+    #             for route in bp_routes
+    #         })
+    #         # https://github.com/ckan/ckan/pull/4521
+    #         config_['ckan.legacy_route_mappings'] = json.dumps(mappings)
+
+    # IConfigurable
+    def configure(self, config):
+        model_setup()
+
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'apis')
+        
 
     def get_actions(self):
         return {
@@ -22,7 +75,9 @@ class ApisPlugin(plugins.SingletonPlugin):
                 'apiset_create': create.apiset_create,
                 'apiset_update': update.apiset_update,
                 'apiset_patch': update.apiset_patch,
-                'apiset_delete': delete.apiset_delete
+                'apiset_delete': delete.apiset_delete,
+                'apiset_package_list': get.apiset_package_list,
+                'package_apiset_list': get.package_apiset_list,
                 }
 
     def before_search(self, search_params):
@@ -34,3 +89,27 @@ class ApisPlugin(plugins.SingletonPlugin):
             search_params['fq'] = fq
 
         return search_params
+
+    def search_template(self):
+        return 'apiset/search.html'
+
+    # IAuthFunctions
+    def get_auth_functions(self):
+        return auth.get_auth_functions()
+
+
+    # ITemplateHelpers
+    def get_helpers(self):
+        return {
+            'get_apiset_pkgs': helpers.get_apiset_pkgs
+        }
+
+    # def is_fallback(self):
+    #     # Return True to register this plugin as the default handler for
+    #     # package types not handled by any other IDatasetForm plugin.
+    #     return True
+
+    # def package_types(self) -> list[str]:
+    #     # This plugin doesn't handle any special package types, it just
+    #     # registers itself as the default (above).
+    #     return []

--- a/ckanext/apis/plugin.py
+++ b/ckanext/apis/plugin.py
@@ -11,13 +11,8 @@ from ckanext.apis.logic import auth
 import json
 import logging
 
-# from ckan.types import Schema
-# import ckan.plugins as p
-# import ckan.plugins.toolkit as tk
-
 
 class ApisPlugin(plugins.SingletonPlugin):
-    # plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IActions)
@@ -25,42 +20,14 @@ class ApisPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IAuthFunctions)
-    # plugins.implements(plugins.IDatasetForm)
-    # plugins.implements(plugins.IFacets, inherit=True)
-
 
     # IBlueprint
     def get_blueprint(self):
         return views.get_blueprint()
 
-    # # IConfigurer
-    # def update_config(self, config_):
-    #     toolkit.add_template_directory(config_, 'templates')
-    #     toolkit.add_public_directory(config_, 'public')
-    #     toolkit.add_resource('fanstatic', 'apis')
-    #     toolkit.add_ckan_admin_tab(config_, 'apis_blueprint.admins', 'Apiset Config')
-
-    #     if toolkit.check_ckan_version(min_version='2.9.0'):
-    #         mappings = config_.get('ckan.legacy_route_mappings', {})
-    #         if isinstance(mappings, string_types):
-    #             mappings = json.loads(mappings)
-
-    #         bp_routes = [
-    #             'index', 'new', 'delete',
-    #             'read', 'edit', 'manage_datasets',
-    #             'apiset_package_list', 'admins', 'admin_remove'
-    #         ]
-    #         mappings.update({
-    #             'apiset_' + route: 'apis_blueprint.' + route
-    #             for route in bp_routes
-    #         })
-    #         # https://github.com/ckan/ckan/pull/4521
-    #         config_['ckan.legacy_route_mappings'] = json.dumps(mappings)
-
     # IConfigurable
     def configure(self, config):
         model_setup()
-
 
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
@@ -78,6 +45,8 @@ class ApisPlugin(plugins.SingletonPlugin):
                 'apiset_delete': delete.apiset_delete,
                 'apiset_package_list': get.apiset_package_list,
                 'package_apiset_list': get.package_apiset_list,
+                'apiset_package_association_create': create.apiset_package_association_create,
+                'apiset_package_association_delete': delete.apiset_package_association_delete,
                 }
 
     def before_search(self, search_params):
@@ -90,26 +59,21 @@ class ApisPlugin(plugins.SingletonPlugin):
 
         return search_params
 
+    def package_form(self):
+        return 'apiset/new_package_form.html'
+
     def search_template(self):
         return 'apiset/search.html'
+        
+    def edit_template(self):
+        return 'apiset/edit_base.html'
 
     # IAuthFunctions
     def get_auth_functions(self):
         return auth.get_auth_functions()
-
 
     # ITemplateHelpers
     def get_helpers(self):
         return {
             'get_apiset_pkgs': helpers.get_apiset_pkgs
         }
-
-    # def is_fallback(self):
-    #     # Return True to register this plugin as the default handler for
-    #     # package types not handled by any other IDatasetForm plugin.
-    #     return True
-
-    # def package_types(self) -> list[str]:
-    #     # This plugin doesn't handle any special package types, it just
-    #     # registers itself as the default (above).
-    #     return []

--- a/ckanext/apis/plugin.py
+++ b/ckanext/apis/plugin.py
@@ -12,6 +12,7 @@ import os
 import sys
 import json
 import logging
+from ckanext.apis.logic.converters import save_to_groups
 
 
 class ApisPlugin(plugins.SingletonPlugin):
@@ -22,6 +23,8 @@ class ApisPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IAuthFunctions)
+    plugins.implements(plugins.IValidators)
+
 
     # IBlueprint
     def get_blueprint(self):
@@ -49,6 +52,13 @@ class ApisPlugin(plugins.SingletonPlugin):
                 'apiset_package_association_create': create.apiset_package_association_create,
                 'apiset_package_association_delete': delete.apiset_package_association_delete,
                 }
+
+    # IValidators
+    def get_validators(self):
+        return {
+            # NOTE: this is a converter. (https://github.com/vrk-kpa/ckanext-scheming/#validators)
+            'save_to_groups': save_to_groups,
+        }   
 
     def before_search(self, search_params):
         '''Prevents the apisets being shown in dataset search results.'''
@@ -84,7 +94,7 @@ class ApisPlugin(plugins.SingletonPlugin):
     # The following methods copied from ckan.lib.plugins.DefaultTranslation so
     # we don't have to mix it into the class. This means we can use Apiset
     # even if ITranslation isn't available (less than 2.5).
-    
+
     def i18n_directory(self):
             '''Change the directory of the *.mo translation files
             The default implementation assumes the plugin is

--- a/ckanext/apis/schemas/apiset.json
+++ b/ckanext/apis/schemas/apiset.json
@@ -199,20 +199,6 @@
       "required": true,
       "validators": "boolean_validator",
       "group_title": "Other information"
-    },
-    {
-      "field_name": "update_frequency",
-      "label": "Update frequency",
-      "form_placeholder":"eg. every second week",
-      "form_languages": ["fi", "en", "sv"],
-      "preset": "fluent_vocabulary_with_autocomplete",
-      "validators": "fluent_tags create_fluent_tags(update_frequency)",
-      "form_attrs": {
-        "data-module": "autocomplete",
-        "data-module-tags": "",
-        "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?&vocabulary_id=update_frequency"
-      },
-      "description": "A short description of how frequently the data in the API will get updated."
     }
   ]
 }

--- a/ckanext/apis/templates/apiset/edit.html
+++ b/ckanext/apis/templates/apiset/edit.html
@@ -1,0 +1,14 @@
+{% extends 'apiset/edit_base.html' %}
+
+{% block wrapper_class %} ckanext-apis-edit-wrapper{% endblock %}
+
+{% block ckanext_apis_edit_span %}span12{% endblock %}
+
+{% block primary_content_inner %}
+  {% block form %}
+  {#- passing c to a snippet is bad but is required here
+      for backwards compatibility with old templates and
+      plugins using setup_template_variables() -#}
+  {{- h.snippet(form_snippet, c=c, **form_vars) -}}
+  {% endblock %}
+{% endblock %}

--- a/ckanext/apis/templates/apiset/edit.html
+++ b/ckanext/apis/templates/apiset/edit.html
@@ -1,14 +1,10 @@
 {% extends 'apiset/edit_base.html' %}
 
-{% block wrapper_class %} ckanext-apis-edit-wrapper{% endblock %}
 
-{% block ckanext_apis_edit_span %}span12{% endblock %}
+    {% block primary_content_inner %}
+        {% block form %}
+        {{- h.snippet(form_snippet, pkg_dict=pkg_dict, **form_vars) -}}
+        {% endblock %}
+    {% endblock %}
+    
 
-{% block primary_content_inner %}
-  {% block form %}
-  {#- passing c to a snippet is bad but is required here
-      for backwards compatibility with old templates and
-      plugins using setup_template_variables() -#}
-  {{- h.snippet(form_snippet, c=c, **form_vars) -}}
-  {% endblock %}
-{% endblock %}

--- a/ckanext/apis/templates/apiset/edit_base.html
+++ b/ckanext/apis/templates/apiset/edit_base.html
@@ -1,6 +1,6 @@
 {% extends 'page.html' %}
 
-{% if pkg is not defined %}{% set pkg = c.pkg_dict if c.pkg_dict is defined else {} %}{% endif %}
+{% if pkg is not defined %}{% set pkg = g.pkg_dict if g.pkg_dict is defined else {} %}{% endif %}
 {% set name = h.get_translated(pkg, 'title') or pkg.name %}
 
 

--- a/ckanext/apis/templates/apiset/edit_base.html
+++ b/ckanext/apis/templates/apiset/edit_base.html
@@ -1,0 +1,68 @@
+{% extends 'page.html' %}
+
+{% if pkg is not defined %}{% set pkg = c.pkg_dict if c.pkg_dict is defined else {} %}{% endif %}
+{% set name = h.get_translated(pkg, 'title') or pkg.name %}
+
+
+{% block subtitle %}{{ _('Apisets') }}{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+{% endblock %}
+
+{% block breadcrumb_content_selected %}{% endblock %}
+
+{% block breadcrumb_content %}
+
+{#
+  {% if pkg %}
+    {% set apiset = name %}
+    <li>{% link_for _('Apisets'), named_route='apis.search' %}</li>
+    <li>{{ self.breadcrumb_content_selected() }}{% link_for apiset|truncate(30), named_route='apiset_read', id=pkg.name %}</li>
+    <li class="active">{% link_for _('Edit'), named_route='apiset.edit', id=pkg.name %}</li>
+  {% else %}
+    <li>{% link_for _('Apisets'), named_route='apis.search' %}</li>
+    <li class="active"><a href="">{{ _('Create Apiset') }}</a></li>
+  {% endif %}
+#}
+
+{% endblock %}
+
+
+{% block primary %}
+  <div class="primary {% block ckanext_apiset_edit_span %}span9{% endblock %}">
+    {% block primary_content %}
+      <article>
+        {% block page_header %}
+          <header class="suomifi-page-header">
+            {% if self.content_action() | trim %}
+              <div class="content_action">
+                {% block content_action %}
+                  {% link_for _('View apiset'), named_route='apiset.read', id=pkg.name, class_='btn suomifi-button-secondary-noborder', icon='eye-open' %}
+                {% endblock %}
+              </div>
+            {% endif %}
+            <h1>{{name}}</h1>
+            <ul class="nav">
+              {% block content_primary_nav %}
+                {{ h.build_nav_icon('apiset.edit', _('Edit apiset'), id=pkg.name, icon=None) }}
+                {{ h.build_nav_icon('apis_blueprint.manage_datasets', _('Manage datasets'), id=pkg.name, icon=None) }}
+              {% endblock %}
+            </ul>
+          </header>
+        {% endblock %}
+          {% if self.page_primary_action() | trim %}
+            <div class="page_primary_action">
+              {% block page_primary_action %}{% endblock %}
+            </div>
+          {% endif %}
+          {% block primary_content_inner %}
+          {% endblock %}
+      </article>
+    {% endblock %}
+  </div>
+{% endblock %}
+
+{% block secondary %}
+
+{% endblock %}

--- a/ckanext/apis/templates/apiset/edit_base.html
+++ b/ckanext/apis/templates/apiset/edit_base.html
@@ -41,7 +41,7 @@
             <ul class="nav nav-tabs">
               {% block content_primary_nav %}
                 {{ h.build_nav_icon('apis_blueprint.edit', _('Edit apiset'), id=pkg.name, icon='pencil-square-o') }}
-                {{ h.build_nav_icon('apiset.resources', _('Resources'), id=pkg.name,  icon='bars') }}
+                {{ h.build_nav_icon('apis_blueprint.resources', _('Apisets'), id=pkg.name,  icon='bars') }}
                 {{ h.build_nav_icon('apis_blueprint.manage_datasets', _('Manage datasets'), id=pkg.name, icon=None) }}
               {% endblock %}
             </ul>

--- a/ckanext/apis/templates/apiset/edit_base.html
+++ b/ckanext/apis/templates/apiset/edit_base.html
@@ -13,39 +13,35 @@
 {% block breadcrumb_content_selected %}{% endblock %}
 
 {% block breadcrumb_content %}
-
-{#
   {% if pkg %}
     {% set apiset = name %}
-    <li>{% link_for _('Apisets'), named_route='apis.search' %}</li>
+    <li>{% link_for _('Apisets'), named_route='apiset.search' %}</li>
     <li>{{ self.breadcrumb_content_selected() }}{% link_for apiset|truncate(30), named_route='apiset_read', id=pkg.name %}</li>
     <li class="active">{% link_for _('Edit'), named_route='apiset.edit', id=pkg.name %}</li>
   {% else %}
-    <li>{% link_for _('Apisets'), named_route='apis.search' %}</li>
+    <li>{% link_for _('Apisets'), named_route='apiset.search' %}</li>
     <li class="active"><a href="">{{ _('Create Apiset') }}</a></li>
   {% endif %}
-#}
-
 {% endblock %}
 
 
 {% block primary %}
-  <div class="primary {% block ckanext_apiset_edit_span %}span9{% endblock %}">
+  <div class="">
     {% block primary_content %}
-      <article>
+      <article class="module">
         {% block page_header %}
-          <header class="suomifi-page-header">
+          <header class="page-header">
             {% if self.content_action() | trim %}
               <div class="content_action">
                 {% block content_action %}
-                  {% link_for _('View apiset'), named_route='apiset.read', id=pkg.name, class_='btn suomifi-button-secondary-noborder', icon='eye-open' %}
+                  {% link_for _('View apiset'), named_route='apiset.read', id=pkg.name, class_='btn', icon='eye-open' %}
                 {% endblock %}
               </div>
             {% endif %}
-            <h1>{{name}}</h1>
-            <ul class="nav">
+            <ul class="nav nav-tabs">
               {% block content_primary_nav %}
-                {{ h.build_nav_icon('apiset.edit', _('Edit apiset'), id=pkg.name, icon=None) }}
+                {{ h.build_nav_icon('apis_blueprint.edit', _('Edit apiset'), id=pkg.name, icon='pencil-square-o') }}
+                {{ h.build_nav_icon('apiset.resources', _('Resources'), id=pkg.name,  icon='bars') }}
                 {{ h.build_nav_icon('apis_blueprint.manage_datasets', _('Manage datasets'), id=pkg.name, icon=None) }}
               {% endblock %}
             </ul>

--- a/ckanext/apis/templates/apiset/manage_datasets.html
+++ b/ckanext/apis/templates/apiset/manage_datasets.html
@@ -1,0 +1,136 @@
+{% extends 'apiset/edit_base.html' %}
+
+{% block subtitle %}{{ _('Apiset - Manage datasets') }}{% endblock %}
+
+{% block wrapper_class %} ckanext-apis-edit-wrapper{% endblock %}
+
+{% block ckanext_apis_edit_span %}span12{% endblock %}
+
+{% block ckanext_apis_edit_module_content_class %}{% endblock %}
+
+{% block primary_content_inner %}
+
+<div class="page-container">
+  <section class="apiset-datasets-block">
+    <div>
+      <h3 class="page-heading">
+        {% block apiset_datasets_associated %}
+          {{ _('Datasets in this apiset') }}
+        {% endblock %}
+      </h3>
+      {% if c.apiset_pkgs %}
+        <form method="POST" data-module="basic-form">
+          <table class="table table-bordered table-bulk-edit" data-module="table-selectable-rows">
+            <tbody>
+                {% for package in c.apiset_pkgs %}
+              {#  {% for package in c.page.items %} #}
+                {% set truncate = truncate or 180 %}
+                {% set truncate_title = truncate_title or 80 %}
+                {% set title = package.title or package.name %}
+                {% set notes = h.markdown_extract(h.get_translated(package, 'notes'), extract_length=truncate) %}
+                <tr>
+                  <td class="selectable-row">
+                    <label for="{{ package.type }}_{{ package.id }}">
+                      <input id="{{ package.type }}_{{ package.id }}" class="row-checkbox" type="checkbox" name="{{ package.type }}_{{ package.id }}">
+                      <span class="check"></span>
+                        {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type ~ '.read', id=package.name)) }}
+                    </label>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          <div class="btn-group">
+            <button name="bulk_action.dataset_remove" value="remove" class="btn suomifi-button-secondary" type="submit">
+              <i class="icon-remove"></i>
+              {{ _('Remove from Apiset') }}
+            </button>
+          </div>
+        </form>
+      {% else %}
+        <p class="empty">
+          {% block apiset_no_datasets_associated %}
+            {{ _('This apiset has no datasets associated to it') }}.
+          {% endblock %}
+        </p>
+      {% endif %}
+    </div>
+  </section>
+
+  <h3>
+    {% block apiset_search_and_add_datasets %}
+      {{_("Search and add datasets to an apiset")}}
+    {% endblock %}
+  </h3>
+  <section>
+  {% set facets = {
+    'fields': c.fields_grouped,
+    'search': c.search_facets,
+    'titles': c.facet_titles,
+    'translated_fields': c.translated_fields,
+    'remove_field': c.remove_field }
+  %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_created desc'),
+    (_('Name Ascending'), 'title_string asc'),
+    (_('Name Descending'), 'title_string desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
+  
+  <div>
+
+    
+    {% snippet 'snippets/search_form_with_table_header.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+    
+    
+    {% block package_search_results_list %}
+      {% if c.page.items %}
+        <form method="POST" data-module="basic-form">
+          <div class="action-button-group">
+            <button name="bulk_action.dataset_add" value="add" class="btn suomifi-button-secondary" type="submit">
+              {{ _('Add to Apiset') }}
+            </button>
+          </div>
+          {#{% block errors %}{{ form.errors(error_summary) }}{% endblock %}#}
+          <table class="table table-bordered table-bulk-edit" data-module="table-selectable-rows">
+            <tbody>
+              {% for package in c.page.items %}
+                {% set truncate = truncate or 180 %}
+                {% set truncate_title = truncate_title or 80 %}
+                {% set title = package.title or package.name %}
+                {% set notes = h.markdown_extract(h.get_translated(package, 'notes'), extract_length=truncate) %}
+                <tr>
+                  <td class="selectable-row">
+                    <label for="{{ package.type }}_{{ package.id }}">
+                      <input id="{{ package.type }}_{{ package.id }}" class="row-checkbox" type="checkbox" name="{{ package.type }}_{{ package.id }}">
+                      <span class="check"></span>
+                        {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type ~'.read', id=package.name)) }}
+                    </label>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+            {% if c.page.pager() %}
+              <tfoot>
+                <tr>
+                  <td colspan="2" class="ckanext_apis_pagination_footer">{{ c.page.pager(q=c.q) }}</td>
+                </tr>
+              </tfoot>
+            {% endif %}
+          </table>
+        </form>
+      {% else %}
+        <p class="empty">
+          {% block apiset_no_datasets_found %}
+            {{ _('No datasets could be found') }}
+          {% endblock %}
+        </p>
+      {% endif %}
+    {% endblock %}
+
+  </div>
+    
+  </section>
+</div>
+{% endblock %}

--- a/ckanext/apis/templates/apiset/manage_datasets.html
+++ b/ckanext/apis/templates/apiset/manage_datasets.html
@@ -19,12 +19,12 @@
           {{ _('Datasets in this apiset') }}
         {% endblock %}
       </h3>
-      {% if c.apiset_pkgs %}
+      {% if g.apiset_pkgs %}
         <form method="POST" data-module="basic-form">
           <table class="table table-bordered table-bulk-edit" data-module="table-selectable-rows">
             <tbody>
-                {% for package in c.apiset_pkgs %}
-              {#  {% for package in c.page.items %} #}
+                {% for package in g.apiset_pkgs %}
+              {#  {% for package in g.page.items %} #}
                 {% set truncate = truncate or 180 %}
                 {% set truncate_title = truncate_title or 80 %}
                 {% set title = package.title or package.name %}
@@ -65,11 +65,11 @@
   </h3>
   <section>
   {% set facets = {
-    'fields': c.fields_grouped,
-    'search': c.search_facets,
-    'titles': c.facet_titles,
-    'translated_fields': c.translated_fields,
-    'remove_field': c.remove_field }
+    'fields': g.fields_grouped,
+    'search': g.search_facets,
+    'titles': g.facet_titles,
+    'translated_fields': g.translated_fields,
+    'remove_field': g.remove_field }
   %}
   {% set sorting = [
     (_('Relevance'), 'score desc, metadata_created desc'),
@@ -80,10 +80,10 @@
   %}
   
   <div>
-    {% snippet 'snippets/search_form.html', type='apiset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+    {% snippet 'snippets/search_form.html', type='apiset', query=g.q, sorting=sorting, sorting_selected=g.sort_by_selected, count=g.page.item_count, facets=facets, show_empty=request.params, error=g.query_error, fields=g.fields %}
     
     {% block package_search_results_list %}
-      {% if c.page.items %}
+      {% if g.page.items %}
         <form method="POST" data-module="basic-form">
           <div class="action-button-group">
             <button name="bulk_action.dataset_add" value="add" class="btn suomifi-button-secondary" type="submit">
@@ -93,7 +93,7 @@
           {#{% block errors %}{{ form.errors(error_summary) }}{% endblock %}#}
           <table class="table table-bordered table-bulk-edit" data-module="table-selectable-rows">
             <tbody>
-              {% for package in c.page.items %}
+              {% for package in g.page.items %}
                 {% set truncate = truncate or 180 %}
                 {% set truncate_title = truncate_title or 80 %}
                 {% set title = package.title or package.name %}
@@ -109,10 +109,10 @@
                 </tr>
               {% endfor %}
             </tbody>
-            {% if c.page.pager() %}
+            {% if g.page.pager() %}
               <tfoot>
                 <tr>
-                  <td colspan="2" class="ckanext_apis_pagination_footer">{{ c.page.pager(q=c.q) }}</td>
+                  <td colspan="2" class="ckanext_apis_pagination_footer">{{ g.page.pager(q=g.q) }}</td>
                 </tr>
               </tfoot>
             {% endif %}

--- a/ckanext/apis/templates/apiset/manage_datasets.html
+++ b/ckanext/apis/templates/apiset/manage_datasets.html
@@ -6,7 +6,8 @@
 
 {% block ckanext_apis_edit_span %}span12{% endblock %}
 
-{% block ckanext_apis_edit_module_content_class %}{% endblock %}
+{% block ckanext_apis_edit_module_content_class %}
+{% endblock %}
 
 {% block primary_content_inner %}
 

--- a/ckanext/apis/templates/apiset/manage_datasets.html
+++ b/ckanext/apis/templates/apiset/manage_datasets.html
@@ -80,10 +80,7 @@
   %}
   
   <div>
-
-    
     {% snippet 'snippets/search_form_with_table_header.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
-    
     
     {% block package_search_results_list %}
       {% if c.page.items %}

--- a/ckanext/apis/templates/apiset/manage_datasets.html
+++ b/ckanext/apis/templates/apiset/manage_datasets.html
@@ -80,7 +80,7 @@
   %}
   
   <div>
-    {% snippet 'snippets/search_form_with_table_header.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+    {% snippet 'snippets/search_form.html', type='apiset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
     
     {% block package_search_results_list %}
       {% if c.page.items %}

--- a/ckanext/apis/templates/apiset/new_package_form.html
+++ b/ckanext/apis/templates/apiset/new_package_form.html
@@ -1,0 +1,84 @@
+{% import 'macros/form.html' as form %}
+{% set action = c.form_action or '' %}
+{% set form_style = c.form_style or c.action %}
+{% set ckan_29_or_higher = h.ckan_version().split('.')[1] | int >= 9 %}
+{% set apiset_read_route = 'apis_blueprint.read' if ckan_29_or_higher else 'apis_read' %}
+{% set apiset_delete_route = 'apis_blueprint.delete' if ckan_29_or_higher else 'apis_delete' %}
+
+
+<form id="dataset-edit" class="dataset-form form-horizontal" method="post" action="{{ action }}" data-module="basic-form" enctype="multipart/form-data">
+
+  <input type="hidden" name="_ckan_phase" value="dataset_new_1" />
+  {# pkg_name used in 3 stage edit #}
+  <input type="hidden" name="pkg_name" value="{{ data.id }}" />
+  {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
+
+  {% block basic_fields %}
+
+      {% block package_basic_fields_title %}
+        {{ form.input('title', id='field-title', label=_('Title'), placeholder=_('eg. A descriptive title'), value=data.title, error=errors.title, classes=['control-full', 'control-large'], attrs={'data-module': 'slug-preview-target'}) }}
+      {% endblock %}
+
+      {% block package_basic_fields_url %}
+        {% set prefix = h.url_for(apiset_read_route, id='') %}
+        {% set domain = h.url_for(apiset_read_route, id='', qualified=true) %}
+        {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+        {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<apiset>'} %}
+
+        {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-apiset'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+      {% endblock %}
+
+      {% block package_basic_fields_description %}
+        {% set editor = h.get_wysiwyg_editor() %}
+        {% if editor == 'ckeditor' %}
+          {% set _type = 'asset' if h.ckan_version().split('.')[1] | int >= 9 else 'resource'  %}
+          {% snippet 'apiset/snippets/ckeditor_' ~ _type ~ '.html' %}
+          {%
+            set ckeditor_attrs = {
+              'data-module': 'apiset-ckeditor',
+              'data-module-site_url': h.url('/', qualified=true)}
+          %}
+          {{ form.textarea('notes', id='editor', label=_('Description'), placeholder=_('eg. Some useful notes about the data'), value=data.notes, error=errors.notes, attrs=ckeditor_attrs)}}
+        {% else %}
+          {{ form.markdown('notes', id='field-notes', label=_('Description'), placeholder=_('eg. Some useful notes about the data'), value=data.notes, error=errors.notes) }}
+        {% endif %}
+      {% endblock %}
+
+      {% block package_basic_fields_tags %}
+        {% set tag_attrs = {'data-module': 'autocomplete', 'data-module-tags': '', 'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?'} %}
+        {{ form.input('tag_string', id='field-tags', label=_('Tags'), placeholder=_('eg. economy, mental health, government'), value=data.tag_string, error=errors.tags, classes=['control-full'], attrs=tag_attrs) }}
+      {% endblock %}
+
+      {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+      {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+      {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+  {% endblock %}
+
+  {% block metadata_fields %}
+    {% block package_metadata_fields_url %}
+      {{ form.input('url', label=_('External link'), id='field-url', placeholder=_('http://www.example.com'), value=data.url, error=errors.url, classes=['control-medium']) }}
+    {% endblock %}
+
+    {% block package_metadata_author %}
+      {{ form.input('author', label=_('Submitted By'), id='field-author', placeholder=_('Joe Bloggs'), value=data.author, error=errors.author, classes=['control-medium']) }}
+
+      {{ form.input('author_email', label=_('Submitter Email'), id='field-author-email', placeholder=_('joe@example.com'), value=data.author_email, error=errors.author_email, classes=['control-medium']) }}
+    {% endblock %}
+  {% endblock %}
+
+  {% block form_actions %}
+      <div class="form-actions">
+          {% block delete_button %}
+              {% if form_style == 'edit' and h.check_access('apiset_delete', {'id': data.id}) and not data.state == 'deleted' %}
+                  {% set locale = h.dump_json({'content': _('Are you sure you want to delete this apiset?')}) %}
+                  <a class="btn btn-danger pull-left" href="{{ h.url_for(apiset_delete_route, id=data.id) }}" data-module="confirm-action" data-module-i18n="{{ locale }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+        {% endif %}
+      {% endblock %}
+      {% block save_button %}
+        <button class="btn btn-primary" type="submit" name="save" value=''>{% block save_button_text %}{% if form_style != 'edit' %}{{ _('Create Apiset') }}{% else %}{{ _('Update Apiset') }}{% endif %}{% endblock %}</button>
+      {% endblock %}
+      {{ form.required_message() }}
+    </div>
+  {% endblock %}
+</form>

--- a/ckanext/apis/templates/apiset/new_package_form.html
+++ b/ckanext/apis/templates/apiset/new_package_form.html
@@ -1,6 +1,6 @@
 {% import 'macros/form.html' as form %}
-{% set action = c.form_action or '' %}
-{% set form_style = c.form_style or c.action %}
+{% set action = g.form_action or '' %}
+{% set form_style = g.form_style or g.action %}
 {% set ckan_29_or_higher = h.ckan_version().split('.')[1] | int >= 9 %}
 {% set apiset_read_route = 'apis_blueprint.read' if ckan_29_or_higher else 'apis_read' %}
 {% set apiset_delete_route = 'apis_blueprint.delete' if ckan_29_or_higher else 'apis_delete' %}

--- a/ckanext/apis/templates/apiset/package_form.html
+++ b/ckanext/apis/templates/apiset/package_form.html
@@ -1,0 +1,26 @@
+{% extends "scheming/package/snippets/package_form.html" %}
+
+{% block stages %}{% endblock %}
+
+
+{% block form_actions %}
+  <div class="form-actions">
+    {% block delete_button %}
+      {% if form_style == 'edit' and h.check_access('apiset_delete', {'id': data.id}) and not data.state == 'deleted' %}
+      <a class="btn suomifi-button-secondary" href="{% url_for 'apiset.delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this apiset?') }}">{% block delete_button_text %}<i class="far fa-trash"></i>{{ _('Delete') }}{% endblock %}</a>
+      {% endif %}
+      <a class="btn suomifi-button-secondary-noborder" href="{% url_for 'dataset.search' %}">{{_("Abort")}}</a>
+    {% endblock %}
+    {% block save_button %}
+      <button class="btn suomifi-button-primary" type="submit" name="save" formenctype="multipart/form-data">{% block save_button_text %}{% if form_style != 'edit' %}{{ _('Create Showcase') }}{% else %}{{ _('Update Apiset') }}{% endif %}{% endblock %}</button>
+    {% endblock %}
+  </div>
+  {% block disclaimer %}
+    <p class="disclaimer">
+      {%- trans -%}
+      By submitting this form, you agree to release the <i>metadata</i> values that you
+      enter into the form under the <a href="http://opendatacommons.org/licenses/odbl/1-0/">Open Database License</a>.
+      {%- endtrans -%}
+    </p>
+  {% endblock %}
+{% endblock %}

--- a/ckanext/apis/templates/apiset/resource_read.html
+++ b/ckanext/apis/templates/apiset/resource_read.html
@@ -1,4 +1,4 @@
-{% extends "package/resource_read.html" %}
+{% extends 'apiset/edit_base.html' %}
 
 {%- set exclude_fields = [
     'name',

--- a/ckanext/apis/templates/apiset/resource_read.html
+++ b/ckanext/apis/templates/apiset/resource_read.html
@@ -17,7 +17,7 @@
   <li class="active"><a href="">{{ h.resource_display_name(res)| truncate(30) }}</a></li>
 
   <section class="module">
-    <p class="apiset-title">{{ h.dataset_display_name(c.package) }}</p>
+    <p class="apiset-title">{{ h.dataset_display_name(g.package) }}</p>
   </section>
 
 {% endblock %}
@@ -33,11 +33,11 @@
     {% if description %}
       {{ description }}
     {% else %}
-      {% set notes = h.extra_translation(c.package, 'notes', markdown=True) %}
+      {% set notes = h.extra_translation(g.package, 'notes', markdown=True) %}
       {% if notes %}
         <h3>{{ _('From the dataset abstract') }}</h3>
         <blockquote>{{ notes }}</blockquote>
-        <p>{% trans dataset=c.package.title, url=h.url_for(controller='package', action='read', id=c.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
+        <p>{% trans dataset=g.package.title, url=h.url_for(controller='package', action='read', id=g.package['name']) %}Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
       {% endif %}
     {% endif %}
   </div>

--- a/ckanext/apis/templates/apiset/resources.html
+++ b/ckanext/apis/templates/apiset/resources.html
@@ -1,0 +1,31 @@
+{% extends "apiset/edit_base.html" %}
+
+{% set has_reorder = pkg_dict and pkg_dict.resources and pkg_dict.resources|length > 0 %}
+
+{% block subtitle %}{{ _('Resources') }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
+
+{% block page_primary_action %}
+  {% link_for _('Add new resource'), named_route=pkg_dict.type ~ '_resource.new', id=pkg_dict.name, class_='btn btn-primary', icon='plus' %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  {% if pkg.resources %}
+    <ul class="resource-list"{% if has_reorder %} data-module="resource-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
+      {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+      {% for resource in pkg.resources %}
+        {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=true, can_edit=can_edit, is_activity_archive=False %}
+      {% endfor %}
+    </ul>
+  {% else %}
+    {% trans url=h.url_for(pkg.type ~ '_resource.new', id=pkg.name) %}
+      <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+    {% endtrans %}
+  {% endif %}
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if has_reorder %}
+    {% asset 'vendor/reorder' %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/apis/templates/apiset/search.html
+++ b/ckanext/apis/templates/apiset/search.html
@@ -1,0 +1,57 @@
+{% extends "package/search.html" %}
+{% import 'macros/form.html' as form %}
+{% set ckan_29_or_higher = h.ckan_version().split('.')[1] | int >= 9 %}
+{% set apiset_index_route = 'apis_blueprint.index' if ckan_29_or_higher else 'apiset_index' %}
+{% set apiset_new_route = 'apis_blueprint.new' if ckan_29_or_higher else 'apiset_new' %}
+
+
+{% block subtitle %}{{ _("Apisets") }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Apisets'), named_route=apiset_index_route, highlight_actions = 'new index') }}</li>
+{% endblock %}
+
+{% block page_primary_action %}
+  {% if h.check_access('apiset_create') %}
+    <div class="page_primary_action">
+      {% link_for _('Add Apiset'), named_route=apiset_new_route, class_='btn btn-primary', icon='plus-square' %}
+    </div>
+  {% endif %}
+{% endblock %}
+
+{% block form %}
+  {% set facets = {
+    'fields': c.fields_grouped,
+    'search': c.search_facets,
+    'titles': c.facet_titles,
+    'translated_fields': c.translated_fields,
+    'remove_field': h.facet_remove_field }
+  %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'title_string asc'),
+    (_('Name Descending'), 'title_string desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
+  {% snippet 'apiset/snippets/apiset_search_form.html', type='apiset', placeholder=_('Search apisets...'), query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields, no_bottom_border=true %}
+{% endblock %}
+
+{% block package_search_results_list %}
+  {{ h.snippet('apiset/snippets/apiset_list.html', packages=c.page.items) }}
+{% endblock %}
+
+{% block package_search_results_api %}
+{% endblock %}
+
+{% block secondary_content %}
+{{ h.snippet('apiset/snippets/helper.html') }}
+<div class="filters">
+  <div>
+    {% for facet in c.facet_titles %}
+      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+    {% endfor %}
+  </div>
+  <a class="close no-text hide-filters"><i class="fa fa-times-circle icon-remove-sign"></i><span class="text">close</span></a>
+</div>
+{% endblock %}

--- a/ckanext/apis/templates/apiset/search.html
+++ b/ckanext/apis/templates/apiset/search.html
@@ -21,10 +21,10 @@
 
 {% block form %}
   {% set facets = {
-    'fields': c.fields_grouped,
-    'search': c.search_facets,
-    'titles': c.facet_titles,
-    'translated_fields': c.translated_fields,
+    'fields': g.fields_grouped,
+    'search': g.search_facets,
+    'titles': g.facet_titles,
+    'translated_fields': g.translated_fields,
     'remove_field': h.facet_remove_field }
   %}
   {% set sorting = [
@@ -34,11 +34,11 @@
     (_('Last Modified'), 'metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
-  {% snippet 'apiset/snippets/apiset_search_form.html', type='apiset', placeholder=_('Search apisets...'), query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields, no_bottom_border=true %}
+  {% snippet 'apiset/snippets/apiset_search_form.html', type='apiset', placeholder=_('Search apisets...'), query=g.q, sorting=sorting, sorting_selected=g.sort_by_selected, count=g.page.item_count, facets=facets, show_empty=request.params, error=g.query_error, fields=g.fields, no_bottom_border=true %}
 {% endblock %}
 
 {% block package_search_results_list %}
-  {{ h.snippet('apiset/snippets/apiset_list.html', packages=c.page.items) }}
+  {{ h.snippet('apiset/snippets/apiset_list.html', packages=g.page.items) }}
 {% endblock %}
 
 {% block package_search_results_api %}
@@ -48,8 +48,8 @@
 {{ h.snippet('apiset/snippets/helper.html') }}
 <div class="filters">
   <div>
-    {% for facet in c.facet_titles %}
-      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+    {% for facet in g.facet_titles %}
+      {{ h.snippet('snippets/facet_list.html', title=g.facet_titles[facet], name=facet) }}
     {% endfor %}
   </div>
   <a class="close no-text hide-filters"><i class="fa fa-times-circle icon-remove-sign"></i><span class="text">close</span></a>

--- a/ckanext/apis/templates/apiset/snippets/apiset_search_form.html
+++ b/ckanext/apis/templates/apiset/snippets/apiset_search_form.html
@@ -1,0 +1,7 @@
+{% extends "snippets/search_form.html" %}
+
+{% block search_title %}
+{% if not no_title %}
+  <h1>{% snippet 'apiset/snippets/apiset_search_result_text.html', query=query, count=count, type=type %}</h1>
+{% endif %}
+{% endblock %}

--- a/ckanext/apis/templates/apiset/snippets/apiset_search_result_text.html
+++ b/ckanext/apis/templates/apiset/snippets/apiset_search_result_text.html
@@ -1,0 +1,25 @@
+{#
+
+    Based on snippets/search_result_text.html
+    
+#}
+    {% if type == 'apiset' %}
+      {% set text_query = ungettext("{number} apiset found for '{query}'", "{number} apisets found for '{query}'", count) %}
+      {% set text_query_none = _("No apisets found for '{query}'") %}
+      {% set text_no_query = ungettext("{number} apiset found", "{number} apisets found", count) %}
+      {% set text_no_query_none = _("No apisets found") %}
+    {%- endif -%}
+    
+    {% if query %}
+      {%- if count -%}
+        {{ text_query.format(number=h.localised_number(count), query=query) }}
+      {%- else -%}
+        {{ text_query_none.format(query=query) }}
+      {%- endif -%}
+    {%- else -%}
+      {%- if count -%}
+        {{ text_no_query.format(number=h.localised_number(count)) }}
+      {%- else -%}
+        {{ text_no_query_none }}
+      {%- endif -%}
+    {%- endif -%}

--- a/ckanext/apis/templates/scheming/package/edit.html
+++ b/ckanext/apis/templates/scheming/package/edit.html
@@ -1,0 +1,5 @@
+{% if dataset_type == 'apiset' %}
+  {% extends "apiset/edit.html" %}
+{% else %}
+  {% ckan_extends %}
+{% endif %}

--- a/ckanext/apis/templates/scheming/package/resources.html
+++ b/ckanext/apis/templates/scheming/package/resources.html
@@ -1,0 +1,5 @@
+{% if dataset_type == 'apiset' %}
+  {% extends "apiset/resources.html" %}
+{% else %}
+  {% ckan_extends %}
+{% endif %}

--- a/ckanext/apis/utils.py
+++ b/ckanext/apis/utils.py
@@ -259,7 +259,7 @@ def manage_datasets_view(id):
     data_dict = {'id': id}
 
     try:
-        toolkit.check_access('package_update', context)
+        toolkit.check_access('package_update', context, data_dict)
     except toolkit.NotAuthorized:
         return toolkit.abort(401, _('User not authorized to edit {apiset_id}').format(apiset_id=id))
 
@@ -305,8 +305,7 @@ def manage_datasets_view(id):
             successful_adds = []
             for package_id in package_ids:
                 try:
-                    toolkit.get_action(
-                        'apiset_package_association_create')(
+                    toolkit.get_action('apiset_package_association_create')(
                             context, {
                                 'apiset_id': toolkit.c.pkg_dict['id'],
                                 'package_id': package_id

--- a/ckanext/apis/utils.py
+++ b/ckanext/apis/utils.py
@@ -25,6 +25,25 @@ _encode_params = dataset._encode_params
 c = toolkit.c
 log = logging.getLogger(__name__)
 
+def check_edit_view_auth(id):
+    context = {
+        'model': model,
+        'session': model.Session,
+        'user': c.user or c.author,
+        'auth_user_obj': c.userobj,
+        'save': 'save' in toolkit.request.params,
+        'moderated': toolkit.config.get('moderated'),
+        'pending': True
+    }
+    data_dict = {'id': id}
+
+    try:
+        #toolkit.check_access('apiset_update', context)
+        toolkit.check_access('package_update', context, data_dict)
+    except toolkit.NotAuthorized:
+        return toolkit.abort(
+            401,
+            _(f'User not authorized to edit {id}'))
 
 def check_new_view_auth():
     context = {

--- a/ckanext/apis/utils.py
+++ b/ckanext/apis/utils.py
@@ -38,7 +38,6 @@ def check_edit_view_auth(id):
     data_dict = {'id': id}
 
     try:
-        #toolkit.check_access('apiset_update', context)
         toolkit.check_access('package_update', context, data_dict)
     except toolkit.NotAuthorized:
         return toolkit.abort(
@@ -344,7 +343,6 @@ def manage_datasets_view(id):
 
     _add_dataset_search(toolkit.c.pkg_dict['id'], toolkit.c.pkg_dict['name'])
 
-   # toolkit.c.apiset_pkgs = toolkit.get_action('apiset_list')(
     toolkit.c.apiset_pkgs = toolkit.get_action('apiset_package_list')(
         context, {
             'apiset_id': toolkit.c.pkg_dict['id']

--- a/ckanext/apis/utils.py
+++ b/ckanext/apis/utils.py
@@ -1,0 +1,314 @@
+import logging
+import ckan.views.dataset as dataset
+import ckantoolkit as toolkit
+import ckan.plugins as plugins
+import ckan.logic as logic
+import ckan.lib.helpers as h
+from collections import OrderedDict
+from urllib.parse import urlencode
+from ckan import model
+from ckan.plugins.toolkit import g, config, request, _, asbool
+from .model import ApisetPackageAssociation
+
+
+DATASET_TYPE_NAME = 'apiset'
+NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
+ValidationError = logic.ValidationError
+check_access = logic.check_access
+get_action = logic.get_action
+tuplize_dict = logic.tuplize_dict
+clean_dict = logic.clean_dict
+parse_params = logic.parse_params
+flatten_to_string_key = logic.flatten_to_string_key
+_encode_params = dataset._encode_params
+c = toolkit.c
+log = logging.getLogger(__name__)
+
+
+def _add_dataset_search(apiset_id, apiset_name):
+    from ckan.lib.search import SearchError
+
+    package_type = DATASET_TYPE_NAME
+    # unicode format (decoded from utf8)
+    q = c.q = toolkit.request.params.get('q', u'')
+    c.query_error = False
+    page = h.get_page_number(toolkit.request.params)
+
+    limit = int(toolkit.config.get('ckan.datasets_per_page', 20))
+
+    # most search operations should reset the page counter:
+    params_nopage = [(k, v) for k, v in toolkit.request.params.items()
+                     if k != 'page']
+
+    def drill_down_url(alternative_url=None, **by):
+        return h.add_url_param(alternative_url=alternative_url,
+                               controller=package_type
+                               if toolkit.check_ckan_version('2.9') else 'package',
+                               action='search',
+                               new_params=by)
+
+    c.drill_down_url = drill_down_url
+
+    def remove_field(key, value=None, replace=None):
+        return h.remove_url_param(key,
+                                  value=value,
+                                  replace=replace,
+                                  controller=package_type,
+                                  action='search')
+
+    c.remove_field = remove_field
+
+    sort_by = toolkit.request.params.get('sort', None)
+    params_nosort = [(k, v) for k, v in params_nopage if k != 'sort']
+
+    def _search_url(params, name):
+        url = h.url_for('apis_blueprint.manage_datasets', id=name)
+        return url_with_params(url, params)
+
+    def url_with_params(url, params):
+        params = _encode_params(params)
+        return url + u'?' + urlencode(params)
+
+    def _sort_by(fields):
+        """
+        Sort by the given list of fields.
+        Each entry in the list is a 2-tuple: (fieldname, sort_order)
+        eg - [('metadata_modified', 'desc'), ('name', 'asc')]
+        If fields is empty, then the default ordering is used.
+        """
+        params = params_nosort[:]
+
+        if fields:
+            sort_string = ', '.join('%s %s' % f for f in fields)
+            params.append(('sort', sort_string))
+        return _search_url(params, apiset_name)
+
+    c.sort_by = _sort_by
+    if sort_by is None:
+        c.sort_by_fields = []
+    else:
+        c.sort_by_fields = [field.split()[0] for field in sort_by.split(',')]
+
+    def pager_url(q=None, page=None):
+        params = list(params_nopage)
+        params.append(('page', page))
+        return _search_url(params, apiset_name)
+
+    c.search_url_params = urlencode(_encode_params(params_nopage))
+
+    try:
+        c.fields = []
+        # c.fields_grouped will contain a dict of params containing
+        # a list of values eg {'tags':['tag1', 'tag2']}
+        c.fields_grouped = {}
+        search_extras = {}
+        fq = ''
+        for (param, value) in toolkit.request.params.items():
+            if param not in ['q', 'page', 'sort'] \
+                    and len(value) and not param.startswith('_'):
+                if not param.startswith('ext_'):
+                    c.fields.append((param, value))
+                    fq += ' %s:"%s"' % (param, value)
+                    if param not in c.fields_grouped:
+                        c.fields_grouped[param] = [value]
+                    else:
+                        c.fields_grouped[param].append(value)
+                else:
+                    search_extras[param] = value
+
+        context = {
+            'model': model,
+            'session': model.Session,
+            'user': c.user or c.author,
+            'for_view': True,
+            'auth_user_obj': c.userobj
+        }
+
+
+        # if package_type and package_type != 'dataset':
+        #     # Only show datasets of this particular type
+        #     fq += ' +dataset_type:{type}'.format(type=package_type)
+        # else:
+        #     # Unless changed via config options, don't show non standard
+        #     # dataset types on the default search page
+        #     if not toolkit.asbool(
+        #             toolkit.config.get('ckan.search.show_all_types', 'False')):
+        #         fq += ' +dataset_type:dataset'
+
+        
+        logging.warning(fq)
+        # For now only look for datasets
+        fq = '+dataset_type:dataset'
+
+        # Only search for datasets not already associated with the apiset
+        associated_package_ids = ApisetPackageAssociation.get_package_ids_for_apiset(apiset_id)
+        # flatten resulting list to space separated string
+        if associated_package_ids:
+            associated_package_ids_str = \
+                ' OR '.join([id[0] for id in associated_package_ids])
+            fq += ' !id:({0})'.format(associated_package_ids_str)
+
+
+        facets = OrderedDict()
+
+        default_facet_titles = {
+            'organization': _('Organizations'),
+            'groups': _('Groups'),
+            'tags': _('Tags'),
+            'res_format': _('Formats'),
+            'license_id': _('Licenses'),
+        }
+
+        # for CKAN-Versions that do not provide the facets-method from
+        # helper-context, import facets from ckan.common
+        if hasattr(h, 'facets'):
+            current_facets = h.facets()
+        else:
+            from ckan.common import g
+            current_facets = g.facets
+
+        for facet in current_facets:
+            if facet in default_facet_titles:
+                facets[facet] = default_facet_titles[facet]
+            else:
+                facets[facet] = facet
+
+        # Facet titles
+        for plugin in plugins.PluginImplementations(plugins.IFacets):
+            facets = plugin.dataset_facets(facets, package_type)
+
+        c.facet_titles = facets
+
+        data_dict = {
+            'q': q,
+            'fq': fq.strip(),
+            'facet.field': list(facets.keys()),
+            'rows': limit,
+            'start': (page - 1) * limit,
+            'sort': sort_by,
+            'extras': search_extras
+        }
+        # ###
+        logging.warning(data_dict)
+
+        query = toolkit.get_action('package_search')(context, data_dict)
+        c.sort_by_selected = query['sort']
+
+        c.page = h.Page(collection=query['results'],
+                        page=page,
+                        url=pager_url,
+                        item_count=query['count'],
+                        items_per_page=limit)
+        c.facets = query['facets']
+        c.search_facets = query['search_facets']
+        c.page.items = query['results']
+    except SearchError as se:
+        log.error('Dataset search error: %r', se.args)
+        c.query_error = True
+        c.facets = {}
+        c.search_facets = {}
+        c.page = h.Page(collection=[])
+    c.search_facets_limits = {}
+    for facet in c.search_facets.keys():
+        try:
+            limit = int(
+                toolkit.request.params.get(
+                    '_%s_limit' % facet,
+                    int(toolkit.config.get('search.facets.default', 10))))
+        except toolkit.ValueError:
+            toolkit.abort(
+                400,
+                _("Parameter '{parameter_name}' is not an integer").format(
+                    parameter_name='_%s_limit' % facet))
+        c.search_facets_limits[facet] = limit
+
+    # test code
+    for x in c.page.items or []:
+        logging.warning(x)
+
+
+def manage_datasets_view(id):
+
+    context = {
+        'model': model,
+        'session': model.Session,
+        'user': toolkit.c.user or toolkit.c.author
+    }
+    data_dict = {'id': id}
+
+    try:
+        toolkit.check_access('package_update', context)
+    except toolkit.NotAuthorized:
+        return toolkit.abort(401, _('User not authorized to edit {apiset_id}').format(apiset_id=id))
+
+    try:
+        toolkit.c.pkg_dict = toolkit.get_action('package_show')(context, data_dict)
+    except toolkit.ObjectNotFound:
+        return toolkit.abort(404, _('Apiset not found'))
+    except toolkit.NotAuthorized:
+        return toolkit.abort(401, _('Unauthorized to read apiset'))
+
+    form_data = toolkit.request.form
+
+    manage_route = 'apis_blueprint.manage_datasets'
+
+    if toolkit.request.method == 'POST' and 'bulk_action.dataset_remove' in form_data:
+        # Find the datasets to perform the action on, they are prefixed by dataset_ in the form data
+        package_ids = []
+        for param in form_data:
+            if param.startswith('dataset_'):
+                package_ids.append(param[7:])
+        if package_ids:
+            for package_id in package_ids:
+                toolkit.get_action('apiset_package_association_delete')(
+                    context, {
+                        'apiset_id': toolkit.c.pkg_dict['id'],
+                        'package_id': package_id
+                    })
+            h.flash_success(
+                toolkit.ungettext(
+                    "The dataset has been removed from the apiset.",
+                    "The datasets have been removed from the apiset.",
+                    len(package_ids)))
+            url = h.url_for(manage_route, id=id)
+            return h.redirect_to(url)
+
+    elif toolkit.request.method == 'POST' and 'bulk_action.dataset_add' in form_data:
+        # Find the datasets to perform the action on, they are prefixed by dataset_ in the form data
+        package_ids = []
+        for param in form_data:
+            if param.startswith('dataset_'):
+                package_ids.append(param[7:])
+        if package_ids:
+            successful_adds = []
+            for package_id in package_ids:
+                try:
+                    toolkit.get_action(
+                        'apiset_package_association_create')(
+                            context, {
+                                'apiset_id': toolkit.c.pkg_dict['id'],
+                                'package_id': package_id
+                            })
+                except toolkit.ValidationError as e:
+                    h.flash_notice(e.error_summary)
+                else:
+                    successful_adds.append(package_id)
+            if successful_adds:
+                h.flash_success(
+                    toolkit.ungettext(
+                        "The dataset has been added to the apiset.",
+                        "The datasets have been added to the apiset.",
+                        len(successful_adds)))
+            url = h.url_for(manage_route, id=id)
+            return h.redirect_to(url)
+
+    _add_dataset_search(toolkit.c.pkg_dict['id'], toolkit.c.pkg_dict['name'])
+
+   # toolkit.c.apiset_pkgs = toolkit.get_action('apiset_list')(
+    toolkit.c.apiset_pkgs = toolkit.get_action('apiset_package_list')(
+        context, {
+            'apiset_id': toolkit.c.pkg_dict['id']
+        })
+
+    return toolkit.render('apiset/manage_datasets.html', extra_vars={'view_type': 'manage_datasets'})

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -11,6 +11,12 @@ from ckan.views.home import CACHE_PARAMETERS
 import ckan.lib.navl.dictization_functions as dict_fns
 # from ckanext.showcase import views, utils as showcase_utils
 from . import utils
+# additions
+from typing import Any, Iterable, Optional, Union, cast
+import ckan.model as model
+import json
+
+
 import logging
 
 _setup_template_variables = dataset._setup_template_variables
@@ -27,11 +33,208 @@ NotAuthorized = logic.NotAuthorized
 apis = Blueprint('apis_blueprint', __name__)
 
 
+class EditView(dataset.EditView):
+
+    def post(self, id):
+        context = self._prepare(id)
+        # TODO Check this
+        # utils.check_edit_view_auth(id)
+
+
+        data_dict = dataset.clean_dict(dataset.dict_fns.unflatten(dataset.tuplize_dict(dataset.parse_params(
+            tk.request.form))))
+        data_dict.update(dataset.clean_dict(dataset.dict_fns.unflatten(dataset.tuplize_dict(dataset.parse_params(
+            tk.request.files)))))
+
+
+        test = tk.request.form
+        logging.error(json.dumps(test))
+
+        # Get resource fields and append them to the data_dict
+        old_data = get_action(u'package_show')(context, {u'id': id})
+
+        '''
+        The cleaned data comes in the form of:
+        "title_translated-en": "testi enkku",
+	    "title_translated-fi": "Mun kokoelma testi",
+	    "title_translated-sv": "",
+        
+        while what needs to be saved is
+        "title_translated": {
+            "en": "",
+            "fi": "Mun kokoelma testi",
+            "sv": ""
+        },
+        '''
+
+
+        data = old_data
+        data_dict['id'] = id
+        data['title_translated']['en'] = "enkku testi"
+
+        # logging.error("___old___")
+        # logging.error(json.dumps(data))
+        # logging.error("__new____")
+        # logging.error(json.dumps(data_dict))
+        # logging.error("______")
+        
+
+        data.update(data_dict)
+
+        # logging.error("____update___")
+        # logging.error(json.dumps(data))
+        # logging.error("____________")
+
+        
+        try:
+            pkg = tk.get_action('package_update')(context, data)
+            #pkg = tk.get_action('package_patch')(context, data_dict)
+        except tk.ValidationError as e:
+            errors = e.error_dict
+            error_summary = e.error_summary
+            #return self.get(id, data_dict, errors, error_summary)
+            return self.get(id, data, errors, error_summary)
+
+        tk.c.pkg_dict = pkg
+
+        url = h.url_for('apis_blueprint.read', id=pkg['name'])
+        return h.redirect_to(url)
+
+
+    def get(self, id, data=None, errors=None, error_summary=None):
+        utils.check_new_view_auth()
+        context = self._prepare(id, data)
+        package_type = utils.DATASET_TYPE_NAME
+
+        try:
+            pkg_dict = get_action(u'package_show')(
+                dict(context, for_view=True), {
+                    u'id': id
+                }
+            )
+            context[u'for_edit'] = True
+            old_data = get_action(u'package_show')(context, {u'id': id})
+            # old data is from the database and data is passed from the
+            # user if there is a validation error. Use users data if there.
+            if data:
+                old_data.update(data)
+            data = old_data
+        except (NotFound, NotAuthorized):
+            return base.abort(404, _(u'Apiset not found'))
+        # are we doing a multiphase add?
+        if data.get(u'state', u'').startswith(u'draft'):
+            g.form_action = h.url_for(u'{}.new'.format(package_type))
+            g.form_style = u'new'
+
+            return CreateView().get(
+                package_type,
+                data=data,
+                errors=errors,
+                error_summary=error_summary
+            )
+
+        pkg = context.get(u"package")
+        resources_json = h.json.dumps(data.get(u'resources', []))
+
+        try:
+            check_access(u'package_update', context)
+        except NotAuthorized:
+            return base.abort(
+                403,
+                _(u'User %r not authorized to edit %s') % (g.user, id)
+            )
+        # convert tags if not supplied in data
+        if data and not data.get(u'tag_string'):
+            data[u'tag_string'] = u', '.join(
+                h.dict_list_reduce(pkg_dict.get(u'tags', {}), u'name')
+            )
+        errors = errors or {}
+        form_vars = {
+            u'data': data,
+            u'errors': errors,
+            u'error_summary': error_summary,
+            u'action': u'edit',
+            u'dataset_type': package_type,
+            u'form_style': u'edit'
+        }
+        errors_json = h.json.dumps(errors)
+
+        _setup_template_variables(
+            context, {u'id': id}, package_type=package_type
+        )
+
+        # we have already completed stage 1
+        form_vars[u'stage'] = [u'active']
+        if data.get(u'state', u'').startswith(u'draft'):
+            form_vars[u'stage'] = [u'active', u'complete']
+
+        edit_template = 'apiset/edit.html'
+        return base.render(
+            edit_template,
+            extra_vars={
+                u'form_vars': form_vars,
+                u'form_snippet': 'apiset/package_form.html',
+                u'dataset_type': package_type,
+                u'pkg_dict': pkg_dict,
+                u'pkg': pkg,
+                u'resources_json': resources_json,
+                u'errors_json': errors_json,
+                u'view_type': 'apiset_edit'
+            }
+        )
+
+def resources(id, package_type='dataset'):
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'for_view': True,
+        u'auth_user_obj': g.userobj
+    }
+    data_dict = {u'id': id, u'include_tracking': True}
+
+    try:
+        check_access(u'package_update', context, data_dict)
+    except NotFound:
+        return base.abort(404, _(u'Dataset not found'))
+    except NotAuthorized:
+        return base.abort(
+            403,
+            _(u'User %r not authorized to edit %s') % (g.user, id)
+        )
+    # check if package exists
+    try:
+        pkg_dict = get_action(u'package_show')(context, data_dict)
+        pkg = context[u'package']
+    except (NotFound, NotAuthorized):
+        return base.abort(404, _(u'Dataset not found'))
+
+    package_type = pkg_dict[u'type'] or u'dataset'
+    _setup_template_variables(context, {u'id': id}, package_type=package_type)
+
+    # TODO: remove
+    g.pkg_dict = pkg_dict
+    g.pkg = pkg
+
+    return base.render(
+            u'scheming/package/resources.html', {
+            u'dataset_type': package_type,
+            u'pkg_dict': pkg_dict,
+            u'pkg': pkg
+        })
+
+def read(id):
+    # use the default read function
+    return dataset.read('apiset', id)
+
 def manage_datasets(id):
     return utils.manage_datasets_view(id)
 
-
 apis.add_url_rule('/apiset/manage_datasets/<id>', view_func=manage_datasets, methods=[u'GET', u'POST'])
+apis.add_url_rule('/apiset/edit/<id>', view_func=EditView.as_view('edit'), methods=[u'GET', u'POST'])
+apis.add_url_rule('/apiset/resources/<id>', view_func=resources)
+apis.add_url_rule('/apiset/<id>', view_func=read)
+
 
 def get_blueprint():
     return [apis]

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -75,7 +75,6 @@ class EditView(dataset.EditView):
 
         data = old_data
         data_dict['id'] = id
-        data['title_translated']['en'] = "enkku testi"
         data.update(data_dict)
         
         try:

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from flask import Blueprint
+import ckan.lib.base as base
+import ckan.views.dataset as dataset
+import ckan.logic as logic
+import ckantoolkit as tk
+import ckan.lib.helpers as h
+from ckan.common import _, g, request
+from ckan.views.home import CACHE_PARAMETERS
+import ckan.lib.navl.dictization_functions as dict_fns
+# from ckanext.showcase import views, utils as showcase_utils
+from . import utils
+import logging
+
+_setup_template_variables = dataset._setup_template_variables
+_get_pkg_template = dataset._get_pkg_template
+check_access = logic.check_access
+get_action = logic.get_action
+tuplize_dict = logic.tuplize_dict
+clean_dict = logic.clean_dict
+parse_params = logic.parse_params
+flatten_to_string_key = logic.flatten_to_string_key
+NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
+
+apis = Blueprint('apis_blueprint', __name__)
+
+
+def manage_datasets(id):
+    return utils.manage_datasets_view(id)
+
+
+apis.add_url_rule('/apiset/manage_datasets/<id>', view_func=manage_datasets, methods=[u'GET', u'POST'])
+
+def get_blueprint():
+    return [apis]

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -15,6 +15,7 @@ from . import utils
 # additions
 from typing import Any, Iterable, Optional, Union, cast
 import ckan.model as model
+import ckan.logic.validators as validators
 import json
 
 
@@ -38,8 +39,7 @@ class EditView(dataset.EditView):
 
     def post(self, id):
         context = self._prepare(id)
-        # TODO Check this
-        # utils.check_edit_view_auth(id)
+        utils.check_edit_view_auth(id)
 
         data_dict = dataset.clean_dict(dataset.dict_fns.unflatten(dataset.tuplize_dict(dataset.parse_params(
             tk.request.form))))
@@ -72,7 +72,6 @@ class EditView(dataset.EditView):
 
         # Get resource fields and append them to the data_dict
         old_data = get_action(u'package_show')(context, {u'id': id})
-        logging.error(json.dumps(old_data))
 
         data = old_data
         data_dict['id'] = id
@@ -112,17 +111,6 @@ class EditView(dataset.EditView):
             data = old_data
         except (NotFound, NotAuthorized):
             return base.abort(404, _(u'Apiset not found'))
-        # are we doing a multiphase add?
-        if data.get(u'state', u'').startswith(u'draft'):
-            g.form_action = h.url_for(u'{}.new'.format(package_type))
-            g.form_style = u'new'
-
-            return CreateView().get(
-                package_type,
-                data=data,
-                errors=errors,
-                error_summary=error_summary
-            )
 
         pkg = context.get(u"package")
         resources_json = h.json.dumps(data.get(u'resources', []))

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -15,10 +15,9 @@ from . import utils
 # additions
 from typing import Any, Iterable, Optional, Union, cast
 import ckan.model as model
-import ckan.logic.validators as validators
+from ckanext.apis.logic.converters import save_to_groups
+
 import json
-
-
 import logging
 
 _setup_template_variables = dataset._setup_template_variables
@@ -75,8 +74,15 @@ class EditView(dataset.EditView):
 
         data = old_data
         data_dict['id'] = id
+
+        # empty the groups from the old data, validation will fill them from new data
+        data['groups'] = []
+        # The form omits the category field if no categories are selected
+        if not 'category' in data_dict:
+            data_dict['category'] = ""
+
         data.update(data_dict)
-        
+
         try:
             pkg = tk.get_action('package_update')(context, data)
         except tk.ValidationError as e:
@@ -218,7 +224,6 @@ apis.add_url_rule('/apiset/edit/<id>', view_func=EditView.as_view('edit'), metho
 apis.add_url_rule('/apiset/resources/<id>', view_func=resources)
 apis.add_url_rule('/apiset/new', view_func=new)
 apis.add_url_rule('/apiset/<id>', view_func=read)
-
 
 def get_blueprint():
     return [apis]

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -10,13 +10,9 @@ import ckan.lib.helpers as h
 from ckan.common import _, g, request
 from ckan.views.home import CACHE_PARAMETERS
 import ckan.lib.navl.dictization_functions as dict_fns
-# from ckanext.showcase import views, utils as showcase_utils
 from . import utils
-# additions
 from typing import Any, Iterable, Optional, Union, cast
 import ckan.model as model
-from ckanext.apis.logic.converters import save_to_groups
-
 import json
 import logging
 
@@ -90,7 +86,7 @@ class EditView(dataset.EditView):
             error_summary = e.error_summary
             return self.get(id, data, errors, error_summary)
 
-        tk.c.pkg_dict = pkg
+        tk.g.pkg_dict = pkg
 
         url = h.url_for('apis_blueprint.read', id=pkg['name'])
         return h.redirect_to(url)


### PR DESCRIPTION
Datasets can now be associated with an apiset via manage datasets. Also added the new, read, edit and resources routes to the plugin, making overloading them easier. 

![image](https://user-images.githubusercontent.com/24498487/190995884-96ad2f6f-e7d6-46b7-91d7-0705a18fbab4.png)
![image](https://user-images.githubusercontent.com/24498487/190996607-6332caa9-ba97-40b7-83a6-2ac7b864fc28.png)


