### PR TITLE
AV-1844 & AV-1845: updating apiset texts and link urls

### DIFF
--- a/ckanext/apis/i18n/ckanext-apis.pot
+++ b/ckanext/apis/i18n/ckanext-apis.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apis 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-30 06:30+0000\n"
+"POT-Creation-Date: 2022-11-16 13:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -298,7 +298,8 @@ msgstr ""
 msgid "Parameter '{parameter_name}' is not an integer"
 msgstr ""
 
-#: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288 ckanext/apis/views.py:115
+#: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288 ckanext/apis/views.py:117
+#: ckanext/apis/views.py:220
 msgid "Apiset not found"
 msgstr ""
 
@@ -322,12 +323,12 @@ msgid_plural "The datasets have been added to the apiset."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ckanext/apis/views.py:125 ckanext/apis/views.py:184
+#: ckanext/apis/views.py:127 ckanext/apis/views.py:186
 #, python-format
 msgid "User %r not authorized to edit %s"
 msgstr ""
 
-#: ckanext/apis/views.py:180 ckanext/apis/views.py:191
+#: ckanext/apis/views.py:182 ckanext/apis/views.py:193
 msgid "Dataset not found"
 msgstr ""
 
@@ -362,7 +363,6 @@ msgstr ""
 #: ckanext/apis/templates/apiset/edit_base.html:7
 #: ckanext/apis/templates/apiset/edit_base.html:18
 #: ckanext/apis/templates/apiset/edit_base.html:22
-#: ckanext/apis/templates/apiset/edit_base.html:44
 #: ckanext/apis/templates/apiset/search.html:8
 #: ckanext/apis/templates/apiset/search.html:11
 msgid "Apisets"
@@ -383,6 +383,10 @@ msgstr ""
 
 #: ckanext/apis/templates/apiset/edit_base.html:43
 msgid "Edit apiset"
+msgstr ""
+
+#: ckanext/apis/templates/apiset/edit_base.html:44
+msgid "Apiset resources"
 msgstr ""
 
 #: ckanext/apis/templates/apiset/edit_base.html:45

--- a/ckanext/apis/i18n/en_GB/LC_MESSAGES/ckanext-apis.po
+++ b/ckanext/apis/i18n/en_GB/LC_MESSAGES/ckanext-apis.po
@@ -5,15 +5,16 @@
 # 
 # Translators:
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apis 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-30 06:30+0000\n"
+"POT-Creation-Date: 2022-11-16 13:21+0000\n"
 "PO-Revision-Date: 2021-10-29 09:17+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,11 +54,11 @@ msgstr ""
 
 #: ckanext/apis/translations.py:14
 msgid "Title of the API collection"
-msgstr ""
+msgstr "Title of the API"
 
 #: ckanext/apis/translations.py:15
 msgid "Description for the API collection"
-msgstr ""
+msgstr "Description for the API"
 
 #: ckanext/apis/translations.py:16
 msgid "Keywords and categories"
@@ -69,7 +70,7 @@ msgstr ""
 
 #: ckanext/apis/translations.py:18
 msgid "Provider and maintainer of the API collection"
-msgstr ""
+msgstr "Provider and maintainer of the API"
 
 #: ckanext/apis/translations.py:19
 msgid "Name of the API"
@@ -77,7 +78,7 @@ msgstr ""
 
 #: ckanext/apis/translations.py:20
 msgid "API file or link"
-msgstr ""
+msgstr "Link to the API or documentation"
 
 #: ckanext/apis/translations.py:21
 msgid "API user guide"
@@ -306,7 +307,7 @@ msgid "Parameter '{parameter_name}' is not an integer"
 msgstr ""
 
 #: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288
-#: ckanext/apis/views.py:115
+#: ckanext/apis/views.py:117 ckanext/apis/views.py:220
 msgid "Apiset not found"
 msgstr "API not found"
 
@@ -330,12 +331,12 @@ msgid_plural "The datasets have been added to the apiset."
 msgstr[0] "The dataset has been added to the API."
 msgstr[1] "The datasets have been added to the API."
 
-#: ckanext/apis/views.py:125 ckanext/apis/views.py:184
+#: ckanext/apis/views.py:127 ckanext/apis/views.py:186
 #, python-format
 msgid "User %r not authorized to edit %s"
 msgstr ""
 
-#: ckanext/apis/views.py:180 ckanext/apis/views.py:191
+#: ckanext/apis/views.py:182 ckanext/apis/views.py:193
 msgid "Dataset not found"
 msgstr ""
 
@@ -370,7 +371,6 @@ msgstr ""
 #: ckanext/apis/templates/apiset/edit_base.html:7
 #: ckanext/apis/templates/apiset/edit_base.html:18
 #: ckanext/apis/templates/apiset/edit_base.html:22
-#: ckanext/apis/templates/apiset/edit_base.html:44
 #: ckanext/apis/templates/apiset/search.html:8
 #: ckanext/apis/templates/apiset/search.html:11
 msgid "Apisets"
@@ -392,6 +392,10 @@ msgstr "View API"
 #: ckanext/apis/templates/apiset/edit_base.html:43
 msgid "Edit apiset"
 msgstr "Edit API"
+
+#: ckanext/apis/templates/apiset/edit_base.html:44
+msgid "Apiset resources"
+msgstr "Resources"
 
 #: ckanext/apis/templates/apiset/edit_base.html:45
 msgid "Link datasets"

--- a/ckanext/apis/i18n/fi/LC_MESSAGES/ckanext-apis.po
+++ b/ckanext/apis/i18n/fi/LC_MESSAGES/ckanext-apis.po
@@ -7,15 +7,16 @@
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Pasi Laakso <pasi.laakso@gofore.com>, 2022
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apis 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-30 06:30+0000\n"
+"POT-Creation-Date: 2022-11-16 13:21+0000\n"
 "PO-Revision-Date: 2021-10-29 09:17+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -43,7 +44,7 @@ msgstr "esim. my-apis"
 
 #: ckanext/apis/translations.py:11
 msgid "eg. A detailed description"
-msgstr "Kirjoita kuvaus rajapintakokoelmasta"
+msgstr "Kirjoita kuvaus rajapinnasta"
 
 #: ckanext/apis/translations.py:12
 msgid "eg. Maps"
@@ -55,7 +56,7 @@ msgstr "Minun organisaationi"
 
 #: ckanext/apis/translations.py:14
 msgid "Title of the API collection"
-msgstr "Rajapintakokoelman nimi"
+msgstr "Rajapinnan nimi"
 
 #: ckanext/apis/translations.py:15
 msgid "Description for the API collection"
@@ -71,7 +72,7 @@ msgstr "Muut tiedot"
 
 #: ckanext/apis/translations.py:18
 msgid "Provider and maintainer of the API collection"
-msgstr "Rajapintakokoelman tuottaja ja ylläpitäjä"
+msgstr "Rajapinnan tuottaja ja ylläpitäjä"
 
 #: ckanext/apis/translations.py:19
 msgid "Name of the API"
@@ -79,7 +80,7 @@ msgstr "Rajapinnan nimi"
 
 #: ckanext/apis/translations.py:20
 msgid "API file or link"
-msgstr "Rajapinnan tiedosto"
+msgstr "Linkki rajapintaan tai dokumentaatioon"
 
 #: ckanext/apis/translations.py:21
 msgid "API user guide"
@@ -156,8 +157,9 @@ msgid ""
 "Enter the email address of the organisation's customer service, not an email"
 " address of an individual."
 msgstr ""
-"Kirjoita organisaation asiakastuen sähköpostiosoite eikä yksityishenkilöiden"
-" sähköpostiosoitteita. "
+"Kirjoita organisaation asiakastuen sähköpostiosoite ei yksityishenkilön "
+"sähköpostiosoitetta, jotta sähköposti pysyy toimivana myös "
+"henkilöstömuutoksien jälkeen. "
 
 #: ckanext/apis/translations.py:35
 msgid "e.g. opendata@dvv.fi"
@@ -303,7 +305,7 @@ msgid ""
 "Description field."
 msgstr ""
 "Jos rajapinnan käyttö vaatii rekisteröitymisen, kuvaile "
-"rekisteröintiprosessi Kuvaus-kentässä"
+"rekisteröitymisprosessi Kuvaus-kentässä."
 
 #: ckanext/apis/utils.py:45
 msgid "User not authorized to edit {id}"
@@ -339,7 +341,7 @@ msgid "Parameter '{parameter_name}' is not an integer"
 msgstr ""
 
 #: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288
-#: ckanext/apis/views.py:115
+#: ckanext/apis/views.py:117 ckanext/apis/views.py:220
 msgid "Apiset not found"
 msgstr "Rajapintaa ei löytynyt"
 
@@ -365,12 +367,12 @@ msgid_plural "The datasets have been added to the apiset."
 msgstr[0] "Tietoaineisto liitettiin rajapintaan."
 msgstr[1] "Tietoaineistot liitettiin rajapintaan."
 
-#: ckanext/apis/views.py:125 ckanext/apis/views.py:184
+#: ckanext/apis/views.py:127 ckanext/apis/views.py:186
 #, python-format
 msgid "User %r not authorized to edit %s"
 msgstr "Käyttäjällä %r ei ole oikeutta muokata %s"
 
-#: ckanext/apis/views.py:180 ckanext/apis/views.py:191
+#: ckanext/apis/views.py:182 ckanext/apis/views.py:193
 msgid "Dataset not found"
 msgstr "Tietoaineistoa ei löytynyt"
 
@@ -405,7 +407,6 @@ msgstr "Tietoaineisto"
 #: ckanext/apis/templates/apiset/edit_base.html:7
 #: ckanext/apis/templates/apiset/edit_base.html:18
 #: ckanext/apis/templates/apiset/edit_base.html:22
-#: ckanext/apis/templates/apiset/edit_base.html:44
 #: ckanext/apis/templates/apiset/search.html:8
 #: ckanext/apis/templates/apiset/search.html:11
 msgid "Apisets"
@@ -427,6 +428,10 @@ msgstr "Tarkastele rajapintaa"
 #: ckanext/apis/templates/apiset/edit_base.html:43
 msgid "Edit apiset"
 msgstr "Muokkaa rajapintaa"
+
+#: ckanext/apis/templates/apiset/edit_base.html:44
+msgid "Apiset resources"
+msgstr "Resurssit"
 
 #: ckanext/apis/templates/apiset/edit_base.html:45
 msgid "Link datasets"

--- a/ckanext/apis/logic/converters.py
+++ b/ckanext/apis/logic/converters.py
@@ -30,17 +30,16 @@ def save_to_groups(key, data, errors, context):
             group_key = ('groups',) + list(group_patch.keys())[0]
             group_value = list(group_patch.values())[0]
             data[group_key] = group_value
-        else:
-            if isinstance(value, list):
-                data[key] = json.dumps(value)
-                groups_with_details = []
-                for identifier in value:
-                    groups_with_details.append({"name": identifier})
-                group_patch = flatten_list(groups_with_details)
+        elif isinstance(value, list):
+            data[key] = json.dumps(value)
+            groups_with_details = []
+            for identifier in value:
+                groups_with_details.append({"name": identifier})
+            group_patch = flatten_list(groups_with_details)
 
-                for k, v in list(group_patch.items()):
-                    group_key = ('groups',) + k
-                    data[group_key] = v
+            for k, v in list(group_patch.items()):
+                group_key = ('groups',) + k
+                data[group_key] = v
 
     else:
 

--- a/ckanext/apis/templates/apiset/edit_base.html
+++ b/ckanext/apis/templates/apiset/edit_base.html
@@ -41,7 +41,7 @@
             <ul class="nav nav-tabs">
               {% block content_primary_nav %}
                 {{ h.build_nav_icon('apis_blueprint.edit', _('Edit apiset'), id=pkg.name, icon='pencil-square-o') }}
-                {{ h.build_nav_icon('apis_blueprint.resources', _('Apisets'), id=pkg.name,  icon='bars') }}
+                {{ h.build_nav_icon('apis_blueprint.resources', _('Apiset resources'), id=pkg.name,  icon='bars') }}
                 {{ h.build_nav_icon('apis_blueprint.manage_datasets', _('Link datasets'), id=pkg.name, icon=None) }}
               {% endblock %}
             </ul>

--- a/ckanext/apis/templates/apiset/manage_datasets.html
+++ b/ckanext/apis/templates/apiset/manage_datasets.html
@@ -80,7 +80,8 @@
   %}
   
   <div>
-    {% snippet 'snippets/search_form.html', type='apiset', query=g.q, sorting=sorting, sorting_selected=g.sort_by_selected, count=g.page.item_count, facets=facets, show_empty=request.params, error=g.query_error, fields=g.fields, no_bottom_border=True %}
+    {% snippet 'snippets/search_form.html', type='apiset', query=g.q, sorting=sorting, sorting_selected=g.sort_by_selected, 
+      count=g.page.item_count, facets=facets, show_empty=request.params, error=g.query_error, fields=g.fields, no_bottom_border=True %}
     
     {% block package_search_results_list %}
       {% if g.page.items %}

--- a/ckanext/apis/utils.py
+++ b/ckanext/apis/utils.py
@@ -350,3 +350,6 @@ def manage_datasets_view(id):
         })
 
     return toolkit.render('apiset/manage_datasets.html', extra_vars={'view_type': 'manage_datasets'})
+
+
+    


### PR DESCRIPTION
Note! This contains only the module side implementation, refer to #[1738](https://github.com/vrk-kpa/opendata/pull/1738) for the complete implementation

AV-1844:
Updated the following texts to use apiset related terminology:
- Apiset like button title
- Apiset license title and text
- Apiset changelog and changelog page tab + feed
- Apiset search default text
- Apiset edit resources resource ordering button text + info text

AV-1845:
- Changelog links now uses the correct /apiset url
- License linkin to apiset now uses the correct /apiset url