### PR TITLE
Refactor and fix delete translations

### DIFF
--- a/ckanext/apis/i18n/ckanext-apis.pot
+++ b/ckanext/apis/i18n/ckanext-apis.pot
@@ -1,14 +1,14 @@
 # Translations template for ckanext-apis.
-# Copyright (C) 2023 ORGANIZATION
+# Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the ckanext-apis project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apis 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-24 10:28+0000\n"
+"POT-Creation-Date: 2024-04-18 10:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -298,8 +298,10 @@ msgstr ""
 msgid "Parameter '{parameter_name}' is not an integer"
 msgstr ""
 
-#: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288 ckanext/apis/views.py:120
-#: ckanext/apis/views.py:227 ckanext/apis/views.py:239 ckanext/apis/views.py:325
+#: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288 ckanext/apis/views.py:125
+#: ckanext/apis/views.py:190 ckanext/apis/views.py:201 ckanext/apis/views.py:231
+#: ckanext/apis/views.py:243 ckanext/apis/views.py:304 ckanext/apis/views.py:331
+#: ckanext/apis/views.py:347
 msgid "Apiset not found"
 msgstr ""
 
@@ -323,18 +325,23 @@ msgid_plural "The datasets have been added to the apiset."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ckanext/apis/views.py:130 ckanext/apis/views.py:189
+#: ckanext/apis/views.py:135 ckanext/apis/views.py:194
 #, python-format
 msgid "User %r not authorized to edit %s"
 msgstr ""
 
-#: ckanext/apis/views.py:185 ckanext/apis/views.py:196
-msgid "Dataset not found"
-msgstr ""
-
-#: ckanext/apis/views.py:327
+#: ckanext/apis/views.py:306
 #, python-format
 msgid "Unauthorized to read apiset %s"
+msgstr ""
+
+#: ckanext/apis/views.py:335 ckanext/apis/views.py:351
+#, python-format
+msgid "Unauthorized to delete apiset %s"
+msgstr ""
+
+#: ckanext/apis/views.py:338
+msgid "Apiset has been deleted."
 msgstr ""
 
 #: ckanext/apis/logic/auth.py:43
@@ -363,6 +370,18 @@ msgstr ""
 
 #: ckanext/apis/logic/converters.py:16 ckanext/apis/logic/validators.py:24
 msgid "Dataset"
+msgstr ""
+
+#: ckanext/apis/templates/apiset/confirm_delete.html:5
+msgid "Are you sure you want to delete apiset - {name}?"
+msgstr ""
+
+#: ckanext/apis/templates/apiset/confirm_delete.html:8
+msgid "Cancel"
+msgstr ""
+
+#: ckanext/apis/templates/apiset/confirm_delete.html:9
+msgid "Confirm Delete"
 msgstr ""
 
 #: ckanext/apis/templates/apiset/edit_base.html:7

--- a/ckanext/apis/i18n/fi/LC_MESSAGES/ckanext-apis.po
+++ b/ckanext/apis/i18n/fi/LC_MESSAGES/ckanext-apis.po
@@ -1,25 +1,25 @@
 # Translations template for ckanext-apis.
-# Copyright (C) 2023 ORGANIZATION
+# Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the ckanext-apis project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 # 
 # Translators:
-# Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Pasi Laakso <pasi.laakso@gofore.com>, 2022
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
 # Ville Teräväinen, 2022
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023
 # Suvi Nuttunen, 2023
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2023
+# Zharktas <jari-pekka.voutilainen@gofore.com>, 2024
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apis 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-11-24 10:28+0000\n"
+"POT-Creation-Date: 2024-04-18 10:08+0000\n"
 "PO-Revision-Date: 2021-10-29 09:17+0000\n"
-"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2023\n"
+"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2024\n"
 "Language-Team: Finnish (https://app.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -344,14 +344,16 @@ msgid "Parameter '{parameter_name}' is not an integer"
 msgstr ""
 
 #: ckanext/apis/utils.py:258 ckanext/apis/utils.py:288
-#: ckanext/apis/views.py:120 ckanext/apis/views.py:227
-#: ckanext/apis/views.py:239 ckanext/apis/views.py:325
+#: ckanext/apis/views.py:125 ckanext/apis/views.py:190
+#: ckanext/apis/views.py:201 ckanext/apis/views.py:231
+#: ckanext/apis/views.py:243 ckanext/apis/views.py:304
+#: ckanext/apis/views.py:331 ckanext/apis/views.py:347
 msgid "Apiset not found"
 msgstr "Rajapintaa ei löytynyt"
 
 #: ckanext/apis/utils.py:260 ckanext/apis/utils.py:290
 msgid "Unauthorized to read apiset"
-msgstr ""
+msgstr "Ei oikeuksia lukea rajapintaa"
 
 #: ckanext/apis/utils.py:283
 msgid "User not authorized to edit {apiset_id}"
@@ -371,19 +373,24 @@ msgid_plural "The datasets have been added to the apiset."
 msgstr[0] "Tietoaineisto liitettiin rajapintaan."
 msgstr[1] "Tietoaineistot liitettiin rajapintaan."
 
-#: ckanext/apis/views.py:130 ckanext/apis/views.py:189
+#: ckanext/apis/views.py:135 ckanext/apis/views.py:194
 #, python-format
 msgid "User %r not authorized to edit %s"
 msgstr "Käyttäjällä %r ei ole oikeutta muokata %s"
 
-#: ckanext/apis/views.py:185 ckanext/apis/views.py:196
-msgid "Dataset not found"
-msgstr "Tietoaineistoa ei löytynyt"
-
-#: ckanext/apis/views.py:327
+#: ckanext/apis/views.py:306
 #, python-format
 msgid "Unauthorized to read apiset %s"
-msgstr ""
+msgstr "Ei oikeuksia lukea rajapintaa %s"
+
+#: ckanext/apis/views.py:335 ckanext/apis/views.py:351
+#, python-format
+msgid "Unauthorized to delete apiset %s"
+msgstr "Ei oikeutta poistaa rajapintaa %s"
+
+#: ckanext/apis/views.py:338
+msgid "Apiset has been deleted."
+msgstr "Rajapinta on poistettu."
 
 #: ckanext/apis/logic/auth.py:43
 msgid "User {0} not authorized to edit apisets"
@@ -412,6 +419,18 @@ msgstr "Ei löytynyt"
 #: ckanext/apis/logic/converters.py:16 ckanext/apis/logic/validators.py:24
 msgid "Dataset"
 msgstr "Tietoaineisto"
+
+#: ckanext/apis/templates/apiset/confirm_delete.html:5
+msgid "Are you sure you want to delete apiset - {name}?"
+msgstr "Haluatko varmasti poistaa rajapinnan - {name}?"
+
+#: ckanext/apis/templates/apiset/confirm_delete.html:8
+msgid "Cancel"
+msgstr ""
+
+#: ckanext/apis/templates/apiset/confirm_delete.html:9
+msgid "Confirm Delete"
+msgstr ""
 
 #: ckanext/apis/templates/apiset/edit_base.html:7
 #: ckanext/apis/templates/apiset/edit_base.html:18

--- a/ckanext/apis/templates/apiset/confirm_delete.html
+++ b/ckanext/apis/templates/apiset/confirm_delete.html
@@ -1,0 +1,12 @@
+{% extends "package/confirm_delete.html" %}
+
+{% block form %}
+  {% set dataset = h.dataset_display_name(pkg_dict) %}
+  <p>{{ _('Are you sure you want to delete apiset - {name}?').format(name=dataset) }}</p>
+  <p class="form-actions">
+  <form id='confirm-dataset-delete-form' action="{% url_for pkg_dict.type ~ '.delete', id=pkg_dict.name %}" method="post">
+    <button class="btn btn-danger" type="submit" name="cancel" >{{ _('Cancel') }}</button>
+    <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
+  </form>
+  </p>
+{% endblock %}

--- a/ckanext/apis/views.py
+++ b/ckanext/apis/views.py
@@ -36,7 +36,7 @@ apis = Blueprint(
 
 class EditView(dataset.EditView):
 
-    def post(self, id):
+    def post(self, package_type, id):
         if tk.check_ckan_version(min_version='2.10.0'):
             context = self._prepare()
         else:


### PR DESCRIPTION
Refactors blueprint to 2 separate blueprints for adding default prefix and package type to apiset routes, util api is defined in separate blueprint. This also has an affect that routes that don't do anything except call the core route can be removed.

Overrides confirm delete route and template to update the strings to refer apisets instead of datasets.